### PR TITLE
FIFO queues for additive (Pond) tensors

### DIFF
--- a/examples/notebooks/FIFO Queues.ipynb
+++ b/examples/notebooks/FIFO Queues.ipynb
@@ -4,9 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Setup\n",
-    "\n",
-    "Start by importing TF Encrypted. We don't need to import TensorFlow as well but it's often very convenient since we can mix ordinary and encrypted computations."
+    "This notebook shows how to use `tfe.queue.FIFOQueue`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Setup"
    ]
   },
   {
@@ -25,7 +30,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We only need the following step since we want to inspect the computation later in TensorBoard. It should normally be skipped to avoid the implied overhead of generating event and tracing files."
+    "Turn on TFE profling flags since we want to inspect with TensorBoard below."
    ]
   },
   {
@@ -63,28 +68,42 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Computation\n",
+    "# Session\n",
     "\n",
-    "We next define our mixed computation, in this case summing two encrypted (i.e. private) tensors coming from different input providers. Note that we are using ordinary TensorFlow to generate the inputs locally on the providers."
+    "We here prepare a session that is ready to use and be interleaved with graph construction. Note that for this to work we have to specify all players up front."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "INFO:tf_encrypted:Players: ['server0', 'server1', 'server2', 'inputter', 'result-receiver']\n"
+     ]
+    }
+   ],
    "source": [
-    "x = tfe.define_private_input(\"input-provider-x\", lambda: tf.fill([2,2], 2))\n",
-    "y = tfe.define_private_input(\"input-provider-y\", lambda: tf.fill([2,2], 3))\n",
+    "tf.Session.reset('')\n",
+    "tf.reset_default_graph()\n",
     "\n",
-    "z = x + y"
+    "!rm -rf {TENSORBOARD_DIR}\n",
+    "\n",
+    "players = ['server0', 'server1', 'server2', 'inputter', 'result-receiver']\n",
+    "tfe.set_config(tfe.LocalConfig(players))\n",
+    "tfe.set_protocol(tfe.protocol.Pond())\n",
+    "\n",
+    "sess = tfe.Session(disable_optimizations=True)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "At this point `z` contains the encrypted sum. To reveal only the sum to a result receiver you would normally use the following, which decrypts and executes the print function locally on the result receiver:"
+    "We can then create and use our queue, following how this would be done in ordinary TensorFlow."
    ]
   },
   {
@@ -93,67 +112,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# compute_op = tfe.define_output(\"result-receiver\", z, tf.print)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "However, since we are running in a notebook the above wouldn't actually display anything. To get around this we can use the `print_in_notebook` function from `utils` instead.\n",
+    "shape = (5, 5)\n",
     "\n",
-    "We stress that this is only because we are running in a notebook, and using `py_func` is for instance not possible when running in an actual distributed execution context. See the [TensorFlow documentation](https://www.tensorflow.org/api_docs/python/tf/print) for more information."
+    "q = tfe.queue.FIFOQueue(capacity=10, shape=shape)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:From /Users/dahl/work/tf-encrypted/tf-encrypted/examples/notebooks/utils.py:9: py_func (from tensorflow.python.ops.script_ops) is deprecated and will be removed in a future version.\n",
-      "Instructions for updating:\n",
-      "tf.py_func is deprecated in TF V2. Instead, use\n",
-      "    tf.py_function, which takes a python function which manipulates tf eager\n",
-      "    tensors instead of numpy arrays. It's easy to convert a tf eager tensor to\n",
-      "    an ndarray (just call tensor.numpy()) but having access to eager tensors\n",
-      "    means `tf.py_function`s can use accelerators such as GPUs as well as\n",
-      "    being differentiable using a gradient tape.\n",
-      "    \n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:tensorflow:From /Users/dahl/work/tf-encrypted/tf-encrypted/examples/notebooks/utils.py:9: py_func (from tensorflow.python.ops.script_ops) is deprecated and will be removed in a future version.\n",
-      "Instructions for updating:\n",
-      "tf.py_func is deprecated in TF V2. Instead, use\n",
-      "    tf.py_function, which takes a python function which manipulates tf eager\n",
-      "    tensors instead of numpy arrays. It's easy to convert a tf eager tensor to\n",
-      "    an ndarray (just call tensor.numpy()) but having access to eager tensors\n",
-      "    means `tf.py_function`s can use accelerators such as GPUs as well as\n",
-      "    being differentiable using a gradient tape.\n",
-      "    \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "compute_op = tfe.define_output(\"result-receiver\", z, print_in_notebook)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Execution\n",
+    "x = tfe.define_private_input('inputter', lambda: tf.fill(shape, 5))\n",
     "\n",
-    "Having defined our computation we use a `tfe.Session` to run it, optionally passing in a tag when we want event and tracing files to be written.\n",
-    "\n",
-    "Here we first remove previous event and tracing files to make it easier to find the new runs in TensorBoard."
+    "enqueue_op = q.enqueue(x)"
    ]
   },
   {
@@ -162,40 +134,41 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "INFO:tf_encrypted:Players: ['server0', 'server1', 'server2', 'input-provider-x', 'input-provider-y', 'result-receiver']\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[[5. 5.]\n",
-      " [5. 5.]]\n",
-      "[[5. 5.]\n",
-      " [5. 5.]]\n"
+      "WARNING:tensorflow:From /Users/dahl/work/tf-encrypted/tf-encrypted/examples/notebooks/utils.py:9: py_func (from tensorflow.python.ops.script_ops) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "tf.py_func is deprecated in TF V2. Instead, use\n",
+      "    tf.py_function, which takes a python function which manipulates tf eager\n",
+      "    tensors instead of numpy arrays. It's easy to convert a tf eager tensor to\n",
+      "    an ndarray (just call tensor.numpy()) but having access to eager tensors\n",
+      "    means `tf.py_function`s can use accelerators such as GPUs as well as\n",
+      "    being differentiable using a gradient tape.\n",
+      "    \n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:tensorflow:From /Users/dahl/work/tf-encrypted/tf-encrypted/examples/notebooks/utils.py:9: py_func (from tensorflow.python.ops.script_ops) is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "tf.py_func is deprecated in TF V2. Instead, use\n",
+      "    tf.py_function, which takes a python function which manipulates tf eager\n",
+      "    tensors instead of numpy arrays. It's easy to convert a tf eager tensor to\n",
+      "    an ndarray (just call tensor.numpy()) but having access to eager tensors\n",
+      "    means `tf.py_function`s can use accelerators such as GPUs as well as\n",
+      "    being differentiable using a gradient tape.\n",
+      "    \n"
      ]
     }
    ],
    "source": [
-    "!rm -rf {TENSORBOARD_DIR}\n",
+    "y = q.dequeue()\n",
+    "z = y + y\n",
     "\n",
-    "with tfe.Session() as sess:\n",
-    "    sess.run(compute_op, tag='sum')\n",
-    "    sess.run(compute_op, tag='sum')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Inspection\n",
-    "\n",
-    "We can finally inspect our computations in TensorBoard using the tags passed to `sess.run`.\n",
-    "\n",
-    "Note that this is not saved in notebooks so nothing will show below unless you run this yourself."
+    "dequeue_op = tfe.define_output('result-receiver', z, print_in_notebook)"
    ]
   },
   {
@@ -204,9 +177,61 @@
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Queue status: 1/10\n"
+     ]
+    }
+   ],
+   "source": [
+    "sess.run(enqueue_op, tag='enqueue')\n",
+    "\n",
+    "print(\"Queue status: {}/{}\".format(sess.run(q.size()), q.capacity))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[10. 10. 10. 10. 10.]\n",
+      " [10. 10. 10. 10. 10.]\n",
+      " [10. 10. 10. 10. 10.]\n",
+      " [10. 10. 10. 10. 10.]\n",
+      " [10. 10. 10. 10. 10.]]\n",
+      "Queue status: 0/10\n"
+     ]
+    }
+   ],
+   "source": [
+    "sess.run(dequeue_op, tag='dequeue')\n",
+    "\n",
+    "print(\"Queue status: {}/{}\".format(sess.run(q.size()), q.capacity))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Inspection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
      "data": {
       "text/plain": [
-       "Reusing TensorBoard on port 6010 (pid 64858), started 22:39:26 ago. (Use '!kill 64858' to kill it.)"
+       "Reusing TensorBoard on port 6010 (pid 64858), started 22:38:10 ago. (Use '!kill 64858' to kill it.)"
       ]
      },
      "metadata": {},
@@ -226,7 +251,7 @@
        "        "
       ],
       "text/plain": [
-       "<IPython.lib.display.IFrame at 0x111400550>"
+       "<IPython.lib.display.IFrame at 0x10befcc88>"
       ]
      },
      "metadata": {},

--- a/examples/notebooks/utils.py
+++ b/examples/notebooks/utils.py
@@ -1,0 +1,9 @@
+"""
+Various helpers that make using TensorFlow and TF Encrypted in notebooks
+easier.
+"""
+
+import tensorflow as tf
+
+def print_in_notebook(x):
+  return tf.py_func(print, [x], Tout=[])

--- a/tf_encrypted/__init__.py
+++ b/tf_encrypted/__init__.py
@@ -13,6 +13,7 @@ from . import layers
 from . import operations
 from . import protocol
 from . import keras
+from . import queue
 
 
 _all_prot_funcs = protocol.get_all_funcs()
@@ -83,4 +84,5 @@ __all__ = [
     "operations",
     "global_variables_initializer",
     "keras",
+    "queue",
 ]

--- a/tf_encrypted/protocol/pond/__init__.py
+++ b/tf_encrypted/protocol/pond/__init__.py
@@ -5,6 +5,7 @@ from .pond import Pond
 from .pond import PondTensor, PondPublicTensor, PondPrivateTensor, PondMaskedTensor
 from .pond import TFEVariable, TFETensor, TFEInputter
 from .pond import _type
+from .pond import AdditiveFIFOQueue
 from .triple_sources import OnlineTripleSource, QueuedOnlineTripleSource
 
 __all__ = [
@@ -20,4 +21,5 @@ __all__ = [
     "_type",
     "OnlineTripleSource",
     "QueuedOnlineTripleSource",
+    "AdditiveFIFOQueue",
 ]

--- a/tf_encrypted/protocol/pond/queues_test.py
+++ b/tf_encrypted/protocol/pond/queues_test.py
@@ -1,0 +1,45 @@
+# pylint: disable=missing-docstring
+import unittest
+
+import numpy as np
+import tensorflow as tf
+import tf_encrypted as tfe
+
+
+class TestFIFO(unittest.TestCase):
+
+  def setUp(self):
+    tf.reset_default_graph()
+
+  def test_fifo(self):
+
+    shape = (10, 10)
+
+    with tfe.protocol.Pond():
+
+      q = tfe.queue.FIFOQueue(
+          capacity=10,
+          shape=shape,
+      )
+      assert isinstance(q, tfe.protocol.pond.AdditiveFIFOQueue)
+
+      raw = np.full(shape, 5)
+
+      x = tfe.define_private_input("inputter", lambda: tf.convert_to_tensor(raw))
+      assert isinstance(x, tfe.protocol.pond.PondPrivateTensor)
+
+      enqueue_op = q.enqueue(x)
+
+      y = q.dequeue()
+      assert isinstance(y, tfe.protocol.pond.PondPrivateTensor)
+      assert y.backing_dtype == x.backing_dtype
+      assert y.shape == x.shape
+
+    with tfe.Session() as sess:
+      sess.run(enqueue_op)
+      res = sess.run(y.reveal())
+
+      np.testing.assert_array_equal(res, raw)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/tf_encrypted/queue/__init__.py
+++ b/tf_encrypted/queue/__init__.py
@@ -1,0 +1,12 @@
+"""
+Queue data structures.
+"""
+
+from __future__ import absolute_import
+
+from .fifo import FIFOQueue, AbstractFIFOQueue
+
+__all__ = [
+    'FIFOQueue',
+    'AbstractFIFOQueue',
+]

--- a/tf_encrypted/queue/fifo.py
+++ b/tf_encrypted/queue/fifo.py
@@ -1,0 +1,38 @@
+"""
+FIFO queue data structure.
+"""
+
+from __future__ import absolute_import
+import abc
+
+from ..protocol import get_protocol
+
+
+class AbstractFIFOQueue(abc.ABC):
+  """
+  FIFO queues mimicking `tf.queue.FIFOQueue`.
+  """
+
+  @abc.abstractmethod
+  def enqueue(self, tensor):
+    """
+    Push `tensor` onto queue.
+
+    Blocks if queue is full.
+    """
+
+  @abc.abstractmethod
+  def dequeue(self):
+    """
+    Pop tensor from queue.
+
+    Blocks if queue is empty.
+    """
+
+
+def FIFOQueue(capacity, shape, shared_name=None):
+  return get_protocol().fifo_queue(
+      capacity=capacity,
+      shape=shape,
+      shared_name=shared_name,
+  )


### PR DESCRIPTION
Adds `tfe.queue.FIFOQueue` API endpoint as well as a concrete implementation for PondPrivateTensors. In preparation for refactoring these queues are called AdditiveFIFOQueues.