### PR TITLE
Add Keras ReLU layer

### DIFF
--- a/tf_encrypted/keras/layers/__init__.py
+++ b/tf_encrypted/keras/layers/__init__.py
@@ -7,6 +7,7 @@ from tf_encrypted.keras.layers.convolutional import Conv2D
 from tf_encrypted.keras.layers.dense import Dense
 from tf_encrypted.keras.layers.flatten import Flatten
 from tf_encrypted.keras.layers.pooling import AveragePooling2D, MaxPooling2D
+from tf_encrypted.keras.layers.relu import ReLU
 
 
 
@@ -18,4 +19,5 @@ __all__ = [
     'Flatten',
     'AveragePooling2D',
     'MaxPooling2D',
+    'ReLU',
 ]

--- a/tf_encrypted/keras/layers/relu.py
+++ b/tf_encrypted/keras/layers/relu.py
@@ -1,0 +1,51 @@
+"""Activation Layer implementation."""
+from tf_encrypted.keras.engine import Layer
+from tf_encrypted.keras.activations import relu
+
+arg_not_impl_msg = "`{}` argument is not implemented for layer {}"
+
+class ReLU(Layer):
+  """Rectified Linear Unit activation function.
+  With default values, it returns element-wise `max(x, 0)`.
+  Otherwise, it follows:
+  `f(x) = max_value` for `x >= max_value`,
+  `f(x) = x` for `threshold <= x < max_value`,
+  `f(x) = negative_slope * (x - threshold)` otherwise.
+  Input shape:
+      Arbitrary. Use the keyword argument `input_shape`
+      (tuple of integers, does not include the samples axis)
+      when using this layer as the first layer in a model.
+  Output shape:
+      Same shape as the input.
+  Arguments:
+      max_value: float >= 0. Maximum activation value.
+      negative_slope: float >= 0. Negative slope coefficient.
+      threshold: float. Threshold value for thresholded activation.
+  """
+
+  def __init__(self, max_value=None, negative_slope=0, threshold=0, **kwargs):
+    super(ReLU, self).__init__(**kwargs)
+
+    if max_value:
+      raise NotImplementedError(
+          arg_not_impl_msg.format("max_value", "relu"),
+      )
+
+    if negative_slope != 0:
+      raise NotImplementedError(
+          arg_not_impl_msg.format("negative_slope", "relu"),
+      )
+
+    if threshold != 0:
+      raise NotImplementedError(
+          arg_not_impl_msg.format("threshold", "relu"),
+      )
+
+  def build(self, input_shape):
+    self.built = True
+
+  def call(self, inputs):
+    return relu(inputs)
+
+  def compute_output_shape(self, input_shape):
+    return input_shape

--- a/tf_encrypted/keras/layers/relu_test.py
+++ b/tf_encrypted/keras/layers/relu_test.py
@@ -1,0 +1,24 @@
+# pylint: disable=missing-docstring
+import unittest
+
+import tensorflow as tf
+
+import tf_encrypted as tfe
+from tf_encrypted.keras.testing_utils import agreement_test
+
+class TestActivation(unittest.TestCase):
+
+  def setUp(self):
+    tf.reset_default_graph()
+
+  def test_activation_relu(self):
+    self._core_relu()
+
+  def _core_relu(self, **layer_kwargs):
+    agreement_test(tfe.keras.layers.ReLU,
+                   kwargs=layer_kwargs,
+                   input_shape=[1, 5])
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Hey, 

This PR add [`tf.keras.layers.ReLU`](https://www.tensorflow.org/api_docs/python/tf/keras/layers/ReLU).  So people have the option to do `ReLU` instead of `Activation('relu'). 

Thanks.