### PR TITLE
Support multiple outputs in the converter

### DIFF
--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -160,7 +160,7 @@ class TestConvert(unittest.TestCase):
     self._test_with_ndarray_input_fn('squeeze', test_input, protocol='Pond')
 
   def test_split_convert(self):
-    test_input = np.ones([2, 4])
+    test_input = np.random.random([1, 10, 10, 3])
     self._test_with_ndarray_input_fn('split', test_input, protocol='Pond')
 
   def test_sub_convert(self):
@@ -596,7 +596,7 @@ def export_gather(filename, input_shape):
 
 def run_split(input):
   a = tf.placeholder(tf.float32, shape=input.shape, name="input")
-  x = tf.split(a, num_or_size_splits=2, axis=1)
+  x = tf.split(a, num_or_size_splits=3, axis=-1)
   with tf.Session() as sess:
     output = sess.run(x, feed_dict={a: input})
   return output
@@ -604,7 +604,7 @@ def run_split(input):
 
 def export_split(filename, input_shape):
   a = tf.placeholder(tf.float32, shape=input_shape, name="input")
-  x = tf.split(a, num_or_size_splits=2, axis=1)
+  x = tf.split(a, num_or_size_splits=3, axis=-1)
   return export(x, filename)
 
 

--- a/tf_encrypted/convert/convert.py
+++ b/tf_encrypted/convert/convert.py
@@ -83,7 +83,7 @@ class Converter():
       if node.name not in specop_outputs:
 
         output = strip_tensor_info(node.name)
-        inputs = [strip_tensor_info(x) for x in node.input]
+        inputs = [x for x in node.input]
         if node.op == "Placeholder":
           try:
             _, item = inputs_iterable.__next__()
@@ -95,6 +95,18 @@ class Converter():
           continue
 
         self.outputs[output] = register[node.op](self, node, inputs)
+
+        out = register[node.op](self, node, inputs)
+
+        # if the operation returns a list with several ouputs,
+        # identify the outputs node name
+        if isinstance(out, list):
+          output_name = find_output_names(pb_trimmed, node.name)
+          for i, _ in enumerate(out):
+            self.outputs[output_name[i]] = out[i]
+        else:
+          self.outputs[output] = out
+
       else:
         # Register high level special operations
         for s in specop_dict:
@@ -293,3 +305,33 @@ def strip_tensor_info(node_name: str) -> str:
 
 class InvalidArgumentError(Exception):
   pass
+
+
+def find_output_names(pb_trimmed, node_name):
+  """
+  List ouput names for a specific node.
+
+  Add to the output name list if the input name starts with the
+  node name (namespace) of the ops we are registering but
+  not included in the name of the node we are inspecting.
+
+  For example, for the op `split`, based on the node below, the
+  output names are `split` and `split:1`
+
+  node {
+    name: "output/input"
+    op: "Pack"
+    input: "split"
+    input: "split:1"
+    }
+  """
+  output_node = []
+  for n in pb_trimmed:
+    if not n.startswith(node_name):
+      gdf = pb_trimmed[n]
+      inputs = [x for x in gdf.input if x.startswith(node_name)]
+
+    if inputs:
+      output_node += inputs
+
+  return output_node

--- a/tf_encrypted/convert/convert.py
+++ b/tf_encrypted/convert/convert.py
@@ -56,7 +56,7 @@ class Converter():
 
     if inputter_fn is None:
       inputs = []
-    elif isinstance(inputter_fn, list):
+    elif isinstance(inputter_fn, (list, tuple)):
       inputs = inputter_fn
     else:
       inputs = [inputter_fn]
@@ -324,7 +324,11 @@ def find_output_names(pb_trimmed, node_name):
     }
   """
   output_node = []
-  for n in pb_trimmed:
+  node_name_list = list(pb_trimmed.keys())
+  n_i = node_name_list.index(node_name)
+
+  # Forward lookahead from the node we want register
+  for n in node_name_list[n_i + 1:]:
     if not n.startswith(node_name):
       gdf = pb_trimmed[n]
       inputs = [x for x in gdf.input if x.startswith(node_name)]

--- a/tf_encrypted/convert/convert.py
+++ b/tf_encrypted/convert/convert.py
@@ -96,9 +96,9 @@ class Converter():
 
         out = register[node.op](self, node, inputs)
 
-        # if the operation returns a list with several ouputs,
+        # if the operation returns a list or tuple with several ouputs,
         # identify the outputs node name
-        if isinstance(out, list):
+        if isinstance(out, (list, tuple)):
           output_name = find_output_names(pb_trimmed, node.name)
           for i, _ in enumerate(out):
             self.outputs[output_name[i]] = out[i]

--- a/tf_encrypted/convert/convert.py
+++ b/tf_encrypted/convert/convert.py
@@ -94,8 +94,6 @@ class Converter():
           self.outputs[output] = x
           continue
 
-        self.outputs[output] = register[node.op](self, node, inputs)
-
         out = register[node.op](self, node, inputs)
 
         # if the operation returns a list with several ouputs,

--- a/tf_encrypted/convert/register.py
+++ b/tf_encrypted/convert/register.py
@@ -395,7 +395,7 @@ def _split(converter, node: Any, inputs: List[str]) -> Any:
   num_split = node.attr["num_split"].i
   axis_val = axis.attr["value"].tensor.int_val[0]
 
-  return converter.protocol.split(input_out, num_split, axis_val)[0]
+  return converter.protocol.split(input_out, num_split, axis_val)
 
 
 def _pad(converter, node: Any, inputs: List[str]) -> Any:


### PR DESCRIPTION
Hello, 

Currently, the converter doesn't support ops with multiple outputs when the op is not registered as a special op. Here is an attempt to fix this. By doing so, it should fix the issue for the `tf.split` operation identified in this pr #421.

Thanks,