### PR TITLE
Convert inspect module and fixes for #465

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -169,8 +169,8 @@ if config.plaintext:
 
 else:
   logger.info('running prediction securely')
-  c = tfe.convert.convert.Converter()
-  y = c.convert(graph_def, tfe.convert.registry(), 'input-provider', inputs)
+  c = tfe.convert.convert.Converter(tfe.convert.registry())
+  y = c.convert(graph_def, 'input-provider', inputs)
 
   def reveal_output(session, out, feed):
     run_op = out.reveal()

--- a/bin/serve
+++ b/bin/serve
@@ -160,11 +160,12 @@ else:
   print('Securing computation')
   secure_start = time.time()
   c = tfe.convert.convert.Converter(
-      remote_config,
-      tfe.get_protocol(),
-      remote_config.get_player('weights-provider'))
-  y = c.convert(graph_def, tfe.convert.registry(),
-                remote_config.get_player('master'), inputs)
+      tfe.convert.registry(),
+      config=remote_config,
+      protocol=tfe.get_protocol(),
+      model_provider=remote_config.get_player('weights-provider'),
+  )
+  y = c.convert(graph_def, remote_config.get_player('master'), inputs)
   # TODO: do not reveal on the master server
   y = y.reveal()
   secure_end = time.time()

--- a/tf_encrypted/convert/__init__.py
+++ b/tf_encrypted/convert/__init__.py
@@ -1,8 +1,12 @@
 """The TFE Converter."""
 from .convert import Converter
+from .inspect import inspect_subgraph, export, print_from_graphdef
 from .register import registry
 
 __all__ = [
     'Converter',
-    'registry'
+    'export',
+    'inspect_subgraph',
+    'print_from_graphdef',
+    'registry',
 ]

--- a/tf_encrypted/convert/inspect.py
+++ b/tf_encrypted/convert/inspect.py
@@ -1,0 +1,71 @@
+"""Methods for inspecting TF and Keras graphs for """
+import os
+import tempfile
+
+import tensorflow as tf
+
+
+def inspect_subgraph(subgraph, input_shape, sess=None):
+  path = _gen_graph_def(subgraph, input_shape, sess)
+  graph = _read_graph(path)
+  print_graph(graph)
+
+
+def _gen_graph_def(subgraph, input_shape, sess):
+  temp_dir = tempfile.gettempdir()
+  filename = "inspect_{}.pb".format(subgraph.__class__.__name__)
+  filepath = os.path.join(temp_dir, filename)
+
+  if isinstance(input_shape, tuple):
+    input_shape = [1] + list(input_shape)
+  x = tf.zeros(input_shape)
+  y = subgraph(x)
+  return export(y, filepath, sess=sess)
+
+
+def _read_graph(path):
+  with tf.io.gfile.GFile(path, 'rb') as f:
+    graph_def = tf.GraphDef()
+    graph_def.ParseFromString(f.read())
+
+  return graph_def
+
+
+def print_from_graphdef(graphdef):
+  for node in graphdef.node:
+    print("| Name:", node.name, "| Op:", node.op, "|")
+
+
+def export(x: tf.Tensor, filename, sess=None):
+  """Export a GraphDef for the graph connected to x.
+
+  Args:
+    x: The tensor whose parent Graph we want to export.
+    filename: The filename to use for the exported GraphDef.
+    sess: An optional Session object; useful if already operating within a
+        Session context.
+
+  Returns:
+    A filepath pointing to the exported GraphDef.
+  """
+  should_close = False
+  if sess is None:
+    should_close = True
+    sess = tf.Session()
+
+  pred_node_names = ["output"]
+  tf.identity(x, name=pred_node_names[0])
+  graph = tf.graph_util.convert_variables_to_constants(
+      sess,
+      sess.graph.as_graph_def(),
+      pred_node_names
+    )
+
+  graph = tf.graph_util.remove_training_nodes(graph)
+
+  path = tf.io.write_graph(graph, ".", filename, as_text=False)
+
+  if should_close:
+    sess.close()
+
+  return path

--- a/tf_encrypted/private_model.py
+++ b/tf_encrypted/private_model.py
@@ -1,11 +1,16 @@
 """An abstraction for private models."""
-import tensorflow as tf
+import os
+import tempfile
 
+import tensorflow as tf
 from tensorflow.keras import backend as K
 from tensorflow.python.framework import graph_util
 from tensorflow.python.platform import gfile
 from tensorflow.python.framework.graph_util_impl import remove_training_nodes
+
 import tf_encrypted as tfe
+
+_TMPDIR = tempfile.gettempdir()
 
 
 class PrivateModel:
@@ -70,17 +75,17 @@ def load_graph(model_file, model_name=None):
   return graph_def, inputs
 
 
-def secure_model(model):
+def secure_model(model, **converter_kwargs):
   """Secure a plaintext model from the current session."""
   session = K.get_session()
   min_graph = graph_util.convert_variables_to_constants(
       session, session.graph_def, [node.op.name for node in model.outputs])
-  tf.train.write_graph(min_graph, '/tmp', 'model.pb', as_text=False)
+  graph_fname = 'model.pb'
+  tf.train.write_graph(min_graph, _TMPDIR, graph_fname, as_text=False)
 
-  graph_def, inputs = load_graph('/tmp/model.pb')
+  graph_def, inputs = load_graph(os.path.join(_TMPDIR, graph_fname))
 
-  c = tfe.convert.convert.Converter()
-  y = c.convert(remove_training_nodes(graph_def),
-                tfe.convert.registry(), 'input-provider', inputs)
+  c = tfe.convert.convert.Converter(tfe.convert.registry(), **converter_kwargs)
+  y = c.convert(remove_training_nodes(graph_def), 'input-provider', inputs)
 
   return PrivateModel(y)

--- a/tf_encrypted/private_model_test.py
+++ b/tf_encrypted/private_model_test.py
@@ -22,9 +22,8 @@ class TestPrivateModel(unittest.TestCase):
     graph_def = read_graph("matmul.pb")
 
     with tfe.protocol.Pond():
-      c = tfe.convert.convert.Converter()
-      y = c.convert(graph_def, tfe.convert.registry(),
-                    'input-provider', provide_input)
+      c = tfe.convert.convert.Converter(tfe.convert.registry())
+      y = c.convert(graph_def, 'input-provider', provide_input)
 
       model = PrivateModel(y)
 


### PR DESCRIPTION
- Add the `tfe.convert.inspect` module, helping users inspect their Keras models to verify TFE support before converting them.
- Fixes #465 Converter bugs
- Regression testing to prevent future versions of #465.

**Public API change:**
The Converter constructor now takes the registry as a positional argument instead of the `Converter.convert` method.