### PR TITLE
Added support for splitV in tf.split

### DIFF
--- a/tf_encrypted/convert/convert_test.py
+++ b/tf_encrypted/convert/convert_test.py
@@ -187,6 +187,10 @@ class TestConvert(unittest.TestCase):
     test_input = np.random.random([1, 10, 10, 3])
     self._test_with_ndarray_input_fn('split', test_input, protocol='Pond')
 
+  def test_splitV_convert(self):
+    test_input = np.random.random([1, 10, 10, 3])
+    self._test_with_ndarray_input_fn('splitV', test_input, protocol='Pond')
+
   def test_concat_convert(self):
     test_input = np.ones([1, 10, 10, 3])
     self._test_with_ndarray_input_fn('concat', test_input, protocol='Pond')
@@ -639,6 +643,20 @@ def run_split(data):
 def export_split(filename, input_shape):
   a = tf.placeholder(tf.float32, shape=input_shape, name="input")
   x = tf.split(a, num_or_size_splits=3, axis=-1)
+  return export(x, filename)
+
+
+def run_splitV(data):
+  a = tf.placeholder(tf.float32, shape=data.shape, name="input")
+  x = tf.split(a, num_or_size_splits=[1, 1, 1], axis=-1)
+  with tf.Session() as sess:
+    output = sess.run(x, feed_dict={a: data})
+  return output
+
+
+def export_splitV(filename, input_shape):
+  a = tf.placeholder(tf.float32, shape=input_shape, name="input")
+  x = tf.split(a, num_or_size_splits=[1, 1, 1], axis=-1)
   return export(x, filename)
 
 

--- a/tf_encrypted/convert/convert_test.py
+++ b/tf_encrypted/convert/convert_test.py
@@ -187,9 +187,9 @@ class TestConvert(unittest.TestCase):
     test_input = np.random.random([1, 10, 10, 3])
     self._test_with_ndarray_input_fn('split', test_input, protocol='Pond')
 
-  def test_splitV_convert(self):
+  def test_split_v_convert(self):
     test_input = np.random.random([1, 10, 10, 3])
-    self._test_with_ndarray_input_fn('splitV', test_input, protocol='Pond')
+    self._test_with_ndarray_input_fn('split_v', test_input, protocol='Pond')
 
   def test_concat_convert(self):
     test_input = np.ones([1, 10, 10, 3])
@@ -646,7 +646,7 @@ def export_split(filename, input_shape):
   return export(x, filename)
 
 
-def run_splitV(data):
+def run_split_v(data):
   a = tf.placeholder(tf.float32, shape=data.shape, name="input")
   x = tf.split(a, num_or_size_splits=[1, 1, 1], axis=-1)
   with tf.Session() as sess:
@@ -654,7 +654,7 @@ def run_splitV(data):
   return output
 
 
-def export_splitV(filename, input_shape):
+def export_split_v(filename, input_shape):
   a = tf.placeholder(tf.float32, shape=input_shape, name="input")
   x = tf.split(a, num_or_size_splits=[1, 1, 1], axis=-1)
   return export(x, filename)

--- a/tf_encrypted/convert/register.py
+++ b/tf_encrypted/convert/register.py
@@ -47,7 +47,7 @@ def registry():
       'Slice': _slice,
       'Neg': _negative,
       'Split': _split,
-      'SplitV': _splitV,
+      'SplitV': _split_v,
       'Identity': _identity,
       "GatherV2": _gather,
       "dense": _keras_dense,
@@ -398,7 +398,7 @@ def _split(converter, node: Any, inputs: List[str]) -> Any:
 
   return converter.protocol.split(input_out, num_split, axis_val)
 
-def _splitV(converter, node: Any, inputs: List[str]) -> Any:
+def _split_v(converter, node: Any, inputs: List[str]) -> Any:
   x_in = converter.outputs[inputs[0]]
   size_splits = converter.outputs[inputs[1]]
   axis = converter.outputs[inputs[2]]

--- a/tf_encrypted/convert/register.py
+++ b/tf_encrypted/convert/register.py
@@ -47,6 +47,7 @@ def registry():
       'Slice': _slice,
       'Neg': _negative,
       'Split': _split,
+      'SplitV': _splitV,
       'Identity': _identity,
       "GatherV2": _gather,
       "dense": _keras_dense,
@@ -396,6 +397,23 @@ def _split(converter, node: Any, inputs: List[str]) -> Any:
   axis_val = axis.attr["value"].tensor.int_val[0]
 
   return converter.protocol.split(input_out, num_split, axis_val)
+
+def _splitV(converter, node: Any, inputs: List[str]) -> Any:
+  x_in = converter.outputs[inputs[0]]
+  size_splits = converter.outputs[inputs[1]]
+  axis = converter.outputs[inputs[2]]
+
+  if isinstance(x_in, tf.NodeDef):
+    input_out = _nodef_to_private_pond(converter, x_in)
+  else:
+    input_out = x_in
+
+  size_splits = size_splits.attr["value"].tensor
+  size_splits = list(array.array('I', size_splits.tensor_content))
+  axis_val = axis.attr["value"].tensor.int_val[0]
+
+  return converter.protocol.split(input_out, size_splits, axis_val)
+
 
 
 def _pad(converter, node: Any, inputs: List[str]) -> Any:

--- a/tf_encrypted/protocol/pond/pond.py
+++ b/tf_encrypted/protocol/pond/pond.py
@@ -3552,17 +3552,11 @@ def _split_public(
 
   with tf.name_scope("split"):
     with tf.device(prot.server_0.device_name):
-      if isinstance(num_split, int):
-        ys_on_0 = x_on_0.split(num_split, axis=axis)
-      else:
-        ys_on_0 = x_on_0.splitV(num_split, axis=axis)
+      ys_on_0 = x_on_0.split(num_split, axis=axis)
+
 
     with tf.device(prot.server_1.device_name):
-      if isinstance(num_split, int):
-        ys_on_1 = x_on_1.split(num_split, axis=axis)
-      else:
-        ys_on_1 = x_on_1.splitV(num_split, axis=axis)
-
+      ys_on_1 = x_on_1.split(num_split, axis=axis)
 
     return [
         PondPublicTensor(prot, y_on_0, y_on_1, x.is_scaled)
@@ -3579,16 +3573,10 @@ def _split_private(
   with tf.name_scope("split"):
 
     with tf.device(prot.server_0.device_name):
-      if isinstance(num_split, int):
-        ys0 = x0.split(num_split, axis=axis)
-      else:
-        ys0 = x0.splitV(num_split, axis=axis)
+      ys0 = x0.split(num_split, axis=axis)
 
     with tf.device(prot.server_1.device_name):
-      if isinstance(num_split, int):
-        ys1 = x1.split(num_split, axis=axis)
-      else:
-        ys1 = x1.splitV(num_split, axis=axis)
+      ys1 = x1.split(num_split, axis=axis)
 
     return [PondPrivateTensor(prot, y0, y1, x.is_scaled)
             for y0, y1 in zip(ys0, ys1)]
@@ -3606,20 +3594,12 @@ def _split_masked(prot: Pond,
     bs = prot.triple_source.split_mask(a, num_split=num_split, axis=axis)
 
     with tf.device(prot.server_0.device_name):
-      if isinstance(num_split, int):
-        bs0 = a0.split(num_split, axis=axis)
-        betas_on_0 = alpha_on_0.split(num_split, axis=axis)
-      else:
-        bs0 = a0.splitV(num_split, axis=axis)
-        betas_on_0 = alpha_on_0.splitV(num_split, axis=axis)
+      bs0 = a0.split(num_split, axis=axis)
+      betas_on_0 = alpha_on_0.split(num_split, axis=axis)
 
     with tf.device(prot.server_1.device_name):
-      if isinstance(num_split, int):
-        bs1 = a1.split(num_split, axis=axis)
-        betas_on_1 = alpha_on_1.split(num_split, axis=axis)
-      else:
-        bs1 = a1.splitV(num_split, axis=axis)
-        betas_on_1 = alpha_on_1.splitV(num_split, axis=axis)
+      bs1 = a1.split(num_split, axis=axis)
+      betas_on_1 = alpha_on_1.split(num_split, axis=axis)
 
       ys = prot.split(x.unmasked, num_split, axis=axis)
 

--- a/tf_encrypted/protocol/pond/pond.py
+++ b/tf_encrypted/protocol/pond/pond.py
@@ -3545,18 +3545,24 @@ def _gather_masked(
 
 
 def _split_public(
-    prot: Pond, x: PondPublicTensor, num_split: int, axis: int = 0
+    prot: Pond, x: PondPublicTensor, num_split: Union[int, list], axis: int = 0
 ) -> List[PondPublicTensor]:
 
   x_on_0, x_on_1 = x.unwrapped
 
   with tf.name_scope("split"):
-
     with tf.device(prot.server_0.device_name):
-      ys_on_0 = x_on_0.split(num_split, axis=axis)
+      if isinstance(num_split, int):
+        ys_on_0 = x_on_0.split(num_split, axis=axis)
+      else:
+        ys_on_0 = x_on_0.splitV(num_split, axis=axis)
 
     with tf.device(prot.server_1.device_name):
-      ys_on_1 = x_on_1.split(num_split, axis=axis)
+      if isinstance(num_split, int):
+        ys_on_1 = x_on_1.split(num_split, axis=axis)
+      else:
+        ys_on_1 = x_on_1.splitV(num_split, axis=axis)
+
 
     return [
         PondPublicTensor(prot, y_on_0, y_on_1, x.is_scaled)
@@ -3565,7 +3571,7 @@ def _split_public(
 
 
 def _split_private(
-    prot: Pond, x: PondPrivateTensor, num_split: int, axis: int = 0
+    prot: Pond, x: PondPrivateTensor, num_split: Union[int, list], axis: int = 0
 ) -> List[PondPrivateTensor]:
 
   x0, x1 = x.unwrapped
@@ -3573,10 +3579,16 @@ def _split_private(
   with tf.name_scope("split"):
 
     with tf.device(prot.server_0.device_name):
-      ys0 = x0.split(num_split, axis=axis)
+      if isinstance(num_split, int):
+        ys0 = x0.split(num_split, axis=axis)
+      else:
+        ys0 = x0.splitV(num_split, axis=axis)
 
     with tf.device(prot.server_1.device_name):
-      ys1 = x1.split(num_split, axis=axis)
+      if isinstance(num_split, int):
+        ys1 = x1.split(num_split, axis=axis)
+      else:
+        ys1 = x1.splitV(num_split, axis=axis)
 
     return [PondPrivateTensor(prot, y0, y1, x.is_scaled)
             for y0, y1 in zip(ys0, ys1)]
@@ -3584,7 +3596,7 @@ def _split_private(
 
 def _split_masked(prot: Pond,
                   x: PondMaskedTensor,
-                  num_split,
+                  num_split: Union[int, list],
                   axis=0) -> List[PondMaskedTensor]:
 
   a, a0, a1, alpha_on_0, alpha_on_1 = x.unwrapped
@@ -3594,12 +3606,20 @@ def _split_masked(prot: Pond,
     bs = prot.triple_source.split_mask(a, num_split=num_split, axis=axis)
 
     with tf.device(prot.server_0.device_name):
-      bs0 = a0.split(num_split, axis=axis)
-      betas_on_0 = alpha_on_0.split(num_split, axis=axis)
+      if isinstance(num_split, int):
+        bs0 = a0.split(num_split, axis=axis)
+        betas_on_0 = alpha_on_0.split(num_split, axis=axis)
+      else:
+        bs0 = a0.splitV(num_split, axis=axis)
+        betas_on_0 = alpha_on_0.splitV(num_split, axis=axis)
 
     with tf.device(prot.server_1.device_name):
-      bs1 = a1.split(num_split, axis=axis)
-      betas_on_1 = alpha_on_1.split(num_split, axis=axis)
+      if isinstance(num_split, int):
+        bs1 = a1.split(num_split, axis=axis)
+        betas_on_1 = alpha_on_1.split(num_split, axis=axis)
+      else:
+        bs1 = a1.splitV(num_split, axis=axis)
+        betas_on_1 = alpha_on_1.splitV(num_split, axis=axis)
 
       ys = prot.split(x.unmasked, num_split, axis=axis)
 

--- a/tf_encrypted/tensor/int100.py
+++ b/tf_encrypted/tensor/int100.py
@@ -594,7 +594,7 @@ def crt_factory(INT_TYPE, MODULI):  # pylint: disable=invalid-name
       backing = [tf.gather(xi, indices, axis=axis) for xi in self.backing]
       return DenseTensor(backing)
 
-    def split(self, num_split: int, axis: int = 0):
+    def split(self, num_split: Union[int, list], axis: int = 0):
       backings = zip(*[tf.split(xi, num_split, axis=axis)
                        for xi in self.backing])
       return [DenseTensor(backing) for backing in backings]

--- a/tf_encrypted/tensor/native.py
+++ b/tf_encrypted/tensor/native.py
@@ -287,12 +287,8 @@ def native_factory(NATIVE_TYPE, EXPLICIT_MODULUS=None):  # pylint: disable=inval
     def gather(self, indices: list, axis: int = 0):
       return DenseTensor(tf.gather(self.value, indices, axis=axis))
 
-    def split(self, num_split: int, axis: int = 0):
+    def split(self, num_split: Union[int, list], axis: int = 0):
       values = tf.split(self.value, num_split, axis=axis)
-      return [DenseTensor(value) for value in values]
-
-    def splitV(self, size_splits: list, axis: int = 0):
-      values = tf.split(self.value, size_splits, axis=axis)
       return [DenseTensor(value) for value in values]
 
     def reshape(self, axes: Union[tf.Tensor, List[int]]):

--- a/tf_encrypted/tensor/native.py
+++ b/tf_encrypted/tensor/native.py
@@ -291,6 +291,10 @@ def native_factory(NATIVE_TYPE, EXPLICIT_MODULUS=None):  # pylint: disable=inval
       values = tf.split(self.value, num_split, axis=axis)
       return [DenseTensor(value) for value in values]
 
+    def splitV(self, size_splits: list, axis: int = 0):
+      values = tf.split(self.value, size_splits, axis=axis)
+      return [DenseTensor(value) for value in values]
+
     def reshape(self, axes: Union[tf.Tensor, List[int]]):
       return DenseTensor(tf.reshape(self.value, axes))
 


### PR DESCRIPTION
[tf.split](https://www.tensorflow.org/api_docs/python/tf/split) takes as argument ```num_or_size_splits``` which can either be an integer or a list. This PR adds support to the case where ```num_or_size_splits``` is a list.

**Note:** The converter test passes when ```num_or_size_splits``` is set to [1, 1, 1]. But when setting it to [2, 1] the test **fails**, and I'm not sure why - would appreciate help here.
I've tested the conversion with the following model and the result is correct, so there shouldn't be a problem with ```num_or_size_splits=[2, 1]```:
```
class customLayer(tf.keras.layers.Layer):
    def __init__(self):
        super(customLayer, self).__init__()

    def build(self, input_shape):
        pass

    def call(self, input, **kwargs):
        x = tf.split(input, [2, 1], axis=-1)
        return tf.keras.layers.Concatenate(axis=-1)(x)


input_img = tf.keras.layers.Input(shape=(10,10,3))
x = customLayer()(input_img)
model = tf.keras.Model(inputs=input_img, outputs=x)
```