### PR TITLE
Fix converter when the last op returns a list of Tensors

### DIFF
--- a/tf_encrypted/convert/convert.py
+++ b/tf_encrypted/convert/convert.py
@@ -119,6 +119,8 @@ class Converter:
     # identify the outputs node name
     if isinstance(out, (list, tuple)):
       output_name = find_output_names(pb_trimmed, node.name)
+      # If output_name is empty, it means this node
+      # is the last one in the graph
       if not output_name:
         self.outputs[output] = out
       else:
@@ -356,6 +358,5 @@ def find_output_names(pb_trimmed, node_name):
 
     if inputs:
       output_node += inputs
-  print("output node", output_node)
 
   return output_node

--- a/tf_encrypted/convert/convert.py
+++ b/tf_encrypted/convert/convert.py
@@ -119,8 +119,11 @@ class Converter:
     # identify the outputs node name
     if isinstance(out, (list, tuple)):
       output_name = find_output_names(pb_trimmed, node.name)
-      for i, _ in enumerate(out):
-        self.outputs[output_name[i]] = out[i]
+      if not output_name:
+        self.outputs[output] = out
+      else:
+        for i, _ in enumerate(out):
+          self.outputs[output_name[i]] = out[i]
     else:
       self.outputs[output] = out
 
@@ -353,5 +356,6 @@ def find_output_names(pb_trimmed, node_name):
 
     if inputs:
       output_node += inputs
+  print("output node", output_node)
 
   return output_node

--- a/tf_encrypted/convert/convert_test.py
+++ b/tf_encrypted/convert/convert_test.py
@@ -888,11 +888,7 @@ def export(x: tf.Tensor, filename: str, sess=None):
     sess = tf.Session()
 
   pred_node_names = ["output"]
-  if isinstance(x, (list, tuple)):
-    x = tf.identity(x[0], name=pred_node_names[0])
-  else:
-    tf.identity(x, name=pred_node_names[0])
-
+  tf.identity(x, name=pred_node_names[0])
   graph = graph_util.convert_variables_to_constants(
       sess,
       sess.graph.as_graph_def(),

--- a/tf_encrypted/private_model.py
+++ b/tf_encrypted/private_model.py
@@ -32,7 +32,11 @@ class PrivateModel:
     with tfe.Session() as sess:
       sess.run(tf.global_variables_initializer())
 
-      op = self.output_node.reveal()
+      if isinstance(self.output_node, list):
+        op = [n.reveal() for n in self.output_node]
+      else:
+        op = self.output_node.reveal()
+        
       output = sess.run(op, feed_dict={pl: x}, tag=tag)
 
       return output

--- a/tf_encrypted/private_model.py
+++ b/tf_encrypted/private_model.py
@@ -36,7 +36,7 @@ class PrivateModel:
         op = [n.reveal() for n in self.output_node]
       else:
         op = self.output_node.reveal()
-        
+
       output = sess.run(op, feed_dict={pl: x}, tag=tag)
 
       return output


### PR DESCRIPTION
Closes #561 

The converter is crashing when the last node returns a list with of Tensors. It worked properly when the the op with multiple outputs is not the last op. The test for split was working because the list of tensors was getting packed with tf.identity in `export`. So in the test, tf.split wasn't the last node. 

Thanks,