### PR TITLE
Support list of private variables as input to set_weights

### DIFF
--- a/tf_encrypted/keras/engine/base_layer.py
+++ b/tf_encrypted/keras/engine/base_layer.py
@@ -2,12 +2,15 @@
 from abc import ABC
 import logging
 
+import numpy as np
 from tensorflow.keras import backend as K
 from tensorflow.python.keras.utils import generic_utils
 
 import tf_encrypted as tfe
 from tf_encrypted import get_protocol
 from tf_encrypted.keras.engine.base_layer_utils import unique_object_name
+
+from tf_encrypted.protocol.pond import PondPrivateTensor
 
 logger = logging.getLogger('tf_encrypted')
 
@@ -112,20 +115,27 @@ class Layer(ABC):
     """ Sets the weights of the layer.
     Arguments:
       weights: A list of Numpy arrays with shapes and types
-          matching the output of layer.get_weights()
+          matching the output of layer.get_weights() or a list 
+          of private variables
       sess: tfe session"""
 
-    # Define keras weights as private variable
-    tfe_weights_pl = [tfe.define_private_placeholder(w.shape)
-                      for w in weights]
+    weights_val_types = (np.ndarray, PondPrivateTensor)
+    assert isinstance(weights[0], weights_val_types), type(initial_value)
 
     # Assign new keras weights to existing weights defined by
     # default when tfe layer was instantiated
     if not sess:
       sess = K.get_session()
-    for i, w in enumerate(self.weights):
-      fd = tfe_weights_pl[i].feed(weights[i])
-      sess.run(tfe.assign(w, tfe_weights_pl[i]), feed_dict=fd)
+
+    if isinstance(weights[0], np.ndarray):
+      for i, w in enumerate(self.weights):
+        shape = w.shape.as_list()
+        tfe_weights_pl = tfe.define_private_placeholder(shape)
+        fd = tfe_weights_pl.feed(weights[i].reshape(shape))
+        sess.run(tfe.assign(w, tfe_weights_pl), feed_dict=fd)
+    elif isinstance(weights[0], PondPrivateTensor):
+      for i, w in enumerate(self.weights):
+        sess.run(tfe.assign(w, weights[i]))
 
   @property
   def prot(self):

--- a/tf_encrypted/keras/engine/base_layer.py
+++ b/tf_encrypted/keras/engine/base_layer.py
@@ -115,12 +115,12 @@ class Layer(ABC):
     """ Sets the weights of the layer.
     Arguments:
       weights: A list of Numpy arrays with shapes and types
-          matching the output of layer.get_weights() or a list 
+          matching the output of layer.get_weights() or a list
           of private variables
       sess: tfe session"""
 
-    weights_val_types = (np.ndarray, PondPrivateTensor)
-    assert isinstance(weights[0], weights_val_types), type(initial_value)
+    weights_types = (np.ndarray, PondPrivateTensor)
+    assert isinstance(weights[0], weights_types), type(initial_value)
 
     # Assign new keras weights to existing weights defined by
     # default when tfe layer was instantiated

--- a/tf_encrypted/keras/models/sequential_test.py
+++ b/tf_encrypted/keras/models/sequential_test.py
@@ -95,7 +95,6 @@ class TestSequential(unittest.TestCase):
     with tfe.protocol.SecureNN():
       tfe_model = tfe.keras.models.model_from_config(k_config)
       weights_private_var = [tfe.define_private_variable(w) for w in k_weights]
-      print(type(weights_private_var[0]))
       x = tfe.define_private_variable(input_data)
 
     with tfe.Session() as sess:


### PR DESCRIPTION
Hey, 

With this PR, `set_weights` can use a list of private variables as input instead of just numpy array. 

This should help @VMS-6511 when re-factoring some of the examples.

I will re-base this PR, once #584 is merged. 

Thanks,