### PR TITLE
Create tfe.Session() when setting weights

### DIFF
--- a/tf_encrypted/keras/__init__.py
+++ b/tf_encrypted/keras/__init__.py
@@ -5,6 +5,7 @@ from tf_encrypted.keras import engine
 from tf_encrypted.keras import models
 from tf_encrypted.keras import layers
 from tf_encrypted.keras.models import Sequential
+from tf_encrypted.keras import backend
 
 
 __all__ = [
@@ -12,4 +13,5 @@ __all__ = [
     'models',
     'layers',
     'Sequential',
+    'backend'
 ]

--- a/tf_encrypted/keras/__init__.py
+++ b/tf_encrypted/keras/__init__.py
@@ -1,17 +1,17 @@
 """Higher-level layer abstractions built on TF Encrypted."""
 from __future__ import absolute_import
 
-from tf_encrypted.keras import engine
-from tf_encrypted.keras import models
-from tf_encrypted.keras import layers
-from tf_encrypted.keras.models import Sequential
 from tf_encrypted.keras import backend
+from tf_encrypted.keras import engine
+from tf_encrypted.keras import layers
+from tf_encrypted.keras import models
+from tf_encrypted.keras.models import Sequential
 
 
 __all__ = [
+    'backend',
     'engine',
-    'models',
     'layers',
+    'models',
     'Sequential',
-    'backend'
 ]

--- a/tf_encrypted/keras/backend.py
+++ b/tf_encrypted/keras/backend.py
@@ -1,17 +1,7 @@
 """TFE Keras backend"""
-import tensorflow as tf
 from tensorflow.keras import backend as K
 
 import tf_encrypted as tfe
-from tf_encrypted.protocol.pond import PondPrivateVariable
-
-
-# TODO Should be moved outside backend, maybe in pond.py?
-def is_variable_initialized(x):
-  """Test if TFE private variable has been initialized"""
-  assert isinstance(x, PondPrivateVariable), type(x)
-  is_initialized = tf.is_variable_initialized(x.share0.variable)
-  return is_initialized
 
 
 def get_session():

--- a/tf_encrypted/keras/backend.py
+++ b/tf_encrypted/keras/backend.py
@@ -1,9 +1,11 @@
-"""TFE Keras backend"""
+"""TFE Keras backend. Most of the code was
+borrowed from the tf.keras codebase.
+"""
 import threading
 
 from tensorflow.python.framework import ops
-from tensorflow.python.ops import array_ops
 from tensorflow.python.keras.backend import get_graph, name_scope
+from tensorflow.python.ops import array_ops
 
 import tf_encrypted as tfe
 
@@ -20,7 +22,8 @@ def get_session(op_input_list=()):
     session = default_session
     # If the default session is not a TFE Session, create one
     if not isinstance(session, tfe.Session()):
-      session = tfe.Session()
+      _SESSION.session = tfe.Session()
+      session = _SESSION.session
   else:
     if ops.inside_function():
       raise RuntimeError('Cannot get session inside Tensorflow graph function.')

--- a/tf_encrypted/keras/backend.py
+++ b/tf_encrypted/keras/backend.py
@@ -22,7 +22,7 @@ def get_session(op_input_list=()):
     # If the default session is a TFE Session return this session
     if isinstance(default_session, tfe.Session()):
       return default_session
-    else:
+    if not isinstance(default_session, tfe.Session()):
       raise TypeError(
           'The default session should be a tfe.Session(). '
           'You are probably trying to run this graph with '
@@ -35,7 +35,8 @@ def get_session(op_input_list=()):
     if (getattr(_SESSION, 'session', None) is None or
         _SESSION.session.graph is not _current_graph(op_input_list)):
       _SESSION.session = tfe.Session()
-      return _SESSION.session
+      session = _SESSION.session
+    return session
 
 
 def _current_graph(op_input_list):

--- a/tf_encrypted/keras/backend.py
+++ b/tf_encrypted/keras/backend.py
@@ -1,0 +1,34 @@
+"""TFE Keras backend"""
+import tensorflow as tf
+from tensorflow.keras import backend as K
+
+import tf_encrypted as tfe
+from tf_encrypted.protocol.pond import PondPrivateVariable
+
+
+# TODO Should be moved outside backend, maybe in pond.py?
+def is_variable_initialized(x):
+  """Test if TFE private variable has been initialized"""
+  assert isinstance(x, PondPrivateVariable), type(x)
+  is_initialized = tf.is_variable_initialized(x.share0.variable)
+  return is_initialized
+
+
+def get_session():
+  """Returns the TFE session to be used"""
+  sess = K.get_session()
+  # If session is not a tfe.Session, creates one
+  # K.get_session() will return a tfe.Session if
+  # TFE global session was previously set with set_session
+  if not isinstance(sess, tfe.Session):
+    sess = tfe.Session()
+
+  return sess
+
+def set_session(sess):
+  """Sets the global TFE session."""
+  return K.set_session(sess)
+
+def clear_session():
+  """Destroys the current TFE graph and creates a new one"""
+  return K.clear_session()

--- a/tf_encrypted/keras/backend.py
+++ b/tf_encrypted/keras/backend.py
@@ -35,8 +35,8 @@ def get_session(op_input_list=()):
     if (getattr(_SESSION, 'session', None) is None or
         _SESSION.session.graph is not _current_graph(op_input_list)):
       _SESSION.session = tfe.Session()
-      session = _SESSION.session
-    return session
+    session = _SESSION.session
+  return session
 
 
 def _current_graph(op_input_list):

--- a/tf_encrypted/keras/backend.py
+++ b/tf_encrypted/keras/backend.py
@@ -1,24 +1,59 @@
 """TFE Keras backend"""
-from tensorflow.keras import backend as K
+import threading
+
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.keras.backend import get_graph, name_scope
 
 import tf_encrypted as tfe
 
+# This is a thread local object that will hold the default internal TFE session
+# used by TFE Keras. It can be set manually via `set_session(sess)`.
+_SESSION = threading.local()
 
-def get_session():
-  """Returns the TFE session to be used"""
-  sess = K.get_session()
-  # If session is not a tfe.Session, creates one
-  # K.get_session() will return a tfe.Session if
-  # TFE global session was previously set with set_session
-  if not isinstance(sess, tfe.Session):
-    sess = tfe.Session()
 
-  return sess
+def get_session(op_input_list=()):
+  """Returns the session object for the current thread."""
+  global _SESSION
+  default_session = ops.get_default_session()
+  if default_session is not None:
+    session = default_session
+    # If the default session is not a TFE Session, create one
+    if not isinstance(session, tfe.Session()):
+      session = tfe.Session()
+  else:
+    if ops.inside_function():
+      raise RuntimeError('Cannot get session inside Tensorflow graph function.')
+      # If we don't have a session, or that session does not match the current
+      # graph, create and cache a new session.
+    if (getattr(_SESSION, 'session', None) is None or
+        _SESSION.session.graph is not _current_graph(op_input_list)):
 
-def set_session(sess):
-  """Sets the global TFE session."""
-  return K.set_session(sess)
+      _SESSION.session = tfe.Session()
+    session = _SESSION.session
+  return session
+
+
+def _current_graph(op_input_list):
+  """Return the graph members of `op_input_list`, or the current graph."""
+  return ops._get_graph_from_inputs(op_input_list) # pylint: disable=protected-access
+
+
+def set_session(session):
+  """Sets the global TFE session.
+  Arguments:
+      session: A TFE Session.
+  """
+  global _SESSION
+  _SESSION.session = session
+
 
 def clear_session():
   """Destroys the current TFE graph and creates a new one"""
-  return K.clear_session()
+  _SESSION.session = None
+  ops.reset_default_graph()
+  graph = get_graph()
+  with graph.as_default():
+    with name_scope(''):
+      array_ops.placeholder_with_default(
+          False, shape=(), name='keras_placeholder')

--- a/tf_encrypted/keras/engine/base_layer.py
+++ b/tf_encrypted/keras/engine/base_layer.py
@@ -9,6 +9,7 @@ from tensorflow.python.keras.utils import generic_utils
 import tf_encrypted as tfe
 from tf_encrypted import get_protocol
 from tf_encrypted.keras.engine.base_layer_utils import unique_object_name
+from tf_encrypted.keras import backend as KE
 
 from tf_encrypted.protocol.pond import PondPrivateTensor, PondMaskedTensor
 
@@ -135,6 +136,8 @@ class Layer(ABC):
         sess.run(tfe.assign(w, tfe_weights_pl), feed_dict=fd)
     elif isinstance(weights[0], PondPrivateTensor):
       for i, w in enumerate(self.weights):
+        if not sess.run(KE.is_variable_initialized(weights[i])):
+          sess.run(weights[i].initializer)
         sess.run(tfe.assign(w, weights[i]))
 
   @property

--- a/tf_encrypted/keras/engine/base_layer.py
+++ b/tf_encrypted/keras/engine/base_layer.py
@@ -3,10 +3,10 @@ from abc import ABC
 import logging
 
 import numpy as np
-from tensorflow.keras import backend as K
 from tensorflow.python.keras.utils import generic_utils
 
 import tf_encrypted as tfe
+from tf_encrypted.keras import backend as KE
 from tf_encrypted import get_protocol
 from tf_encrypted.keras.engine.base_layer_utils import unique_object_name
 
@@ -125,7 +125,7 @@ class Layer(ABC):
     # Assign new keras weights to existing weights defined by
     # default when tfe layer was instantiated
     if not sess:
-      sess = K.get_session()
+      sess = KE.get_session()
 
     if isinstance(weights[0], np.ndarray):
       for i, w in enumerate(self.weights):

--- a/tf_encrypted/keras/engine/base_layer.py
+++ b/tf_encrypted/keras/engine/base_layer.py
@@ -9,7 +9,6 @@ from tensorflow.python.keras.utils import generic_utils
 import tf_encrypted as tfe
 from tf_encrypted import get_protocol
 from tf_encrypted.keras.engine.base_layer_utils import unique_object_name
-from tf_encrypted.keras import backend as KE
 
 from tf_encrypted.protocol.pond import PondPrivateTensor, PondMaskedTensor
 
@@ -136,8 +135,6 @@ class Layer(ABC):
         sess.run(tfe.assign(w, tfe_weights_pl), feed_dict=fd)
     elif isinstance(weights[0], PondPrivateTensor):
       for i, w in enumerate(self.weights):
-        if not sess.run(KE.is_variable_initialized(weights[i])):
-          sess.run(weights[i].initializer)
         sess.run(tfe.assign(w, weights[i]))
 
   @property

--- a/tf_encrypted/keras/engine/base_layer.py
+++ b/tf_encrypted/keras/engine/base_layer.py
@@ -6,10 +6,9 @@ import numpy as np
 from tensorflow.python.keras.utils import generic_utils
 
 import tf_encrypted as tfe
-from tf_encrypted.keras import backend as KE
 from tf_encrypted import get_protocol
+from tf_encrypted.keras import backend as KE
 from tf_encrypted.keras.engine.base_layer_utils import unique_object_name
-
 from tf_encrypted.protocol.pond import PondPrivateTensor, PondMaskedTensor
 
 logger = logging.getLogger('tf_encrypted')

--- a/tf_encrypted/keras/models/sequential.py
+++ b/tf_encrypted/keras/models/sequential.py
@@ -1,7 +1,6 @@
 """Sequential model API."""
-from tensorflow.keras import backend as K
-
 import tf_encrypted as tfe
+from tf_encrypted.keras import backend as KE
 from tf_encrypted.keras.engine.base_layer import Layer
 from tf_encrypted.keras.engine.input_layer import InputLayer, Input
 
@@ -113,10 +112,12 @@ class Sequential(Layer):
       sess: tfe session"""
 
     if not sess:
-      sess = tfe.Session()
+      #sess = tfe.Session()
+      sess = KE.get_session()
       # Set as keras global session so the
       # model can be run with K.get_session():
-      K.set_session(sess)
+      sess = KE.get_session()
+      KE.set_session(sess)
 
     # Updated weights for each layer
     for layer in self.layers:

--- a/tf_encrypted/keras/models/sequential.py
+++ b/tf_encrypted/keras/models/sequential.py
@@ -1,5 +1,4 @@
 """Sequential model API."""
-import tensorflow as tf
 from tensorflow.keras import backend as K
 
 import tf_encrypted as tfe
@@ -118,8 +117,6 @@ class Sequential(Layer):
       # Set as keras global session so the
       # model can be run with K.get_session():
       K.set_session(sess)
-      # Initialize model weights before setting weights
-      sess.run(tf.global_variables_initializer())
 
     # Updated weights for each layer
     for layer in self.layers:

--- a/tf_encrypted/keras/models/sequential.py
+++ b/tf_encrypted/keras/models/sequential.py
@@ -112,10 +112,6 @@ class Sequential(Layer):
       sess: tfe session"""
 
     if not sess:
-      #sess = tfe.Session()
-      sess = KE.get_session()
-      # Set as keras global session so the
-      # model can be run with K.get_session():
       sess = KE.get_session()
 
     # Updated weights for each layer

--- a/tf_encrypted/keras/models/sequential.py
+++ b/tf_encrypted/keras/models/sequential.py
@@ -117,7 +117,6 @@ class Sequential(Layer):
       # Set as keras global session so the
       # model can be run with K.get_session():
       sess = KE.get_session()
-      KE.set_session(sess)
 
     # Updated weights for each layer
     for layer in self.layers:

--- a/tf_encrypted/keras/models/sequential_test.py
+++ b/tf_encrypted/keras/models/sequential_test.py
@@ -109,15 +109,17 @@ class TestSequential(unittest.TestCase):
 
       tfe_model = tfe.keras.models.model_from_config(k_config)
       weights_private_var = [tfe.define_private_variable(w) for w in k_weights]
-      tfe_model.set_weights(weights_private_var)
-      y = tfe_model(x)
 
-    with KE.get_session() as sess:
-      actual = sess.run(y.reveal())
+      with tfe.Session() as sess:
+        for w in weights_private_var:
+          sess.run(w.initializer)
 
-      np.testing.assert_allclose(actual, expected, rtol=1e-2, atol=1e-4)
+        tfe_model.set_weights(weights_private_var, sess)
+        y = tfe_model(x)
 
-    KE.clear_session()
+        actual = sess.run(y.reveal())
+
+        np.testing.assert_allclose(actual, expected, rtol=1e-2, atol=1e-4)
 
 
   def test_conv_model(self):

--- a/tf_encrypted/keras/models/sequential_test.py
+++ b/tf_encrypted/keras/models/sequential_test.py
@@ -55,8 +55,7 @@ class TestSequential(unittest.TestCase):
     with tfe.protocol.SecureNN():
       x = tfe.define_private_variable(input_data)
 
-      tfe_model = tfe.keras.models.Sequential([])
-      tfe_model = tfe_model.from_config(k_config)
+      tfe_model = Sequential.from_config(k_config)
       tfe_model.set_weights(k_weights)
       y = tfe_model(x)
 

--- a/tf_encrypted/keras/models/sequential_test.py
+++ b/tf_encrypted/keras/models/sequential_test.py
@@ -35,7 +35,9 @@ class TestSequential(unittest.TestCase):
                                                          input_shape)
 
     with tfe.protocol.SecureNN():
-      x = tfe.define_private_variable(input_data)
+      x = tfe.define_private_input(
+          "inputter",
+          lambda: tf.convert_to_tensor(input_data))
 
       tfe_model = tfe.keras.models.model_from_config(k_config)
       tfe_model.set_weights(k_weights)
@@ -53,7 +55,9 @@ class TestSequential(unittest.TestCase):
                                                          input_shape)
 
     with tfe.protocol.SecureNN():
-      x = tfe.define_private_variable(input_data)
+      x = tfe.define_private_input(
+          "inputter",
+          lambda: tf.convert_to_tensor(input_data))
 
       tfe_model = Sequential.from_config(k_config)
       tfe_model.set_weights(k_weights)
@@ -129,7 +133,9 @@ class TestSequential(unittest.TestCase):
       k_config = model.get_config()
 
     with tfe.protocol.SecureNN():
-      x = tfe.define_private_variable(input_data)
+      x = tfe.define_private_input(
+          "inputter",
+          lambda: tf.convert_to_tensor(input_data))
 
       tfe_model = tfe.keras.models.model_from_config(k_config)
       tfe_model.set_weights(k_weights)

--- a/tf_encrypted/keras/models/sequential_test.py
+++ b/tf_encrypted/keras/models/sequential_test.py
@@ -35,13 +35,13 @@ class TestSequential(unittest.TestCase):
                                                          input_shape)
 
     with tfe.protocol.SecureNN():
-      tfe_model = tfe.keras.models.model_from_config(k_config)
       x = tfe.define_private_variable(input_data)
 
-    with tfe.Session() as sess:
-      sess.run(tf.global_variables_initializer())
+      tfe_model = tfe.keras.models.model_from_config(k_config)
       tfe_model.set_weights(k_weights)
       y = tfe_model(x)
+
+    with K.get_session() as sess:
       actual = sess.run(y.reveal())
 
       np.testing.assert_allclose(actual, expected, rtol=1e-2, atol=1e-4)
@@ -53,14 +53,14 @@ class TestSequential(unittest.TestCase):
                                                          input_shape)
 
     with tfe.protocol.SecureNN():
-      tfe_model = tfe.keras.models.Sequential([])
-      tfe_model = tfe_model.from_config(k_config)
       x = tfe.define_private_variable(input_data)
 
-    with tfe.Session() as sess:
-      sess.run(tf.global_variables_initializer())
+      tfe_model = tfe.keras.models.Sequential([])
+      tfe_model = tfe_model.from_config(k_config)
       tfe_model.set_weights(k_weights)
       y = tfe_model(x)
+
+    with K.get_session() as sess:
       actual = sess.run(y.reveal())
 
       np.testing.assert_allclose(actual, expected, rtol=1e-2, atol=1e-4)
@@ -94,14 +94,14 @@ class TestSequential(unittest.TestCase):
                                                          input_shape)
 
     with tfe.protocol.SecureNN():
+      x = tfe.define_private_variable(input_data)
+    
       tfe_model = tfe.keras.models.model_from_config(k_config)
       weights_private_var = [tfe.define_private_variable(w) for w in k_weights]
-      x = tfe.define_private_variable(input_data)
-
-    with tfe.Session() as sess:
-      sess.run(tf.global_variables_initializer())
       tfe_model.set_weights(weights_private_var)
       y = tfe_model(x)
+
+    with K.get_session() as sess:
       actual = sess.run(y.reveal())
 
       np.testing.assert_allclose(actual, expected, rtol=1e-2, atol=1e-4)
@@ -130,13 +130,13 @@ class TestSequential(unittest.TestCase):
       k_config = model.get_config()
 
     with tfe.protocol.SecureNN():
-      tfe_model = tfe.keras.models.model_from_config(k_config)
       x = tfe.define_private_variable(input_data)
 
-    with tfe.Session() as sess:
-      sess.run(tf.global_variables_initializer())
+      tfe_model = tfe.keras.models.model_from_config(k_config)
       tfe_model.set_weights(k_weights)
       y = tfe_model(x)
+
+    with K.get_session() as sess:
       actual = sess.run(y.reveal())
 
       np.testing.assert_allclose(actual, expected, rtol=1e-2, atol=1e-2)

--- a/tf_encrypted/keras/models/sequential_test.py
+++ b/tf_encrypted/keras/models/sequential_test.py
@@ -82,13 +82,13 @@ class TestSequential(unittest.TestCase):
     expected = model.predict(input_data)
 
     with tfe.protocol.SecureNN():
+      x = tfe.define_private_input(
+          "inputter",
+          lambda: tf.convert_to_tensor(input_data))
+
       tfe_model = tfe.keras.models.clone_model(model)
-      x = tfe.define_private_variable(input_data)
 
     with KE.get_session() as sess:
-      # won't work if we re-initialize all the weights
-      # with sess.run(tf.global_variables_initializer())
-      sess.run(x.initializer)
       y = tfe_model(x)
       actual = sess.run(y.reveal())
 

--- a/tf_encrypted/keras/models/sequential_test.py
+++ b/tf_encrypted/keras/models/sequential_test.py
@@ -95,7 +95,7 @@ class TestSequential(unittest.TestCase):
 
     with tfe.protocol.SecureNN():
       x = tfe.define_private_variable(input_data)
-    
+
       tfe_model = tfe.keras.models.model_from_config(k_config)
       weights_private_var = [tfe.define_private_variable(w) for w in k_weights]
       tfe_model.set_weights(weights_private_var)

--- a/tf_encrypted/protocol/pond/__init__.py
+++ b/tf_encrypted/protocol/pond/__init__.py
@@ -2,7 +2,11 @@
 from __future__ import absolute_import
 
 from .pond import Pond
-from .pond import PondTensor, PondPublicTensor, PondPrivateTensor, PondMaskedTensor, PondPrivateVariable
+from .pond import PondTensor
+from .pond import PondPublicTensor
+from .pond import PondPrivateTensor
+from .pond import PondMaskedTensor
+from .pond import PondPrivateVariable
 from .pond import TFEVariable, TFETensor, TFEInputter
 from .pond import _type
 from .pond import AdditiveFIFOQueue

--- a/tf_encrypted/protocol/pond/__init__.py
+++ b/tf_encrypted/protocol/pond/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import absolute_import
 
 from .pond import Pond
-from .pond import PondTensor, PondPublicTensor, PondPrivateTensor, PondMaskedTensor
+from .pond import PondTensor, PondPublicTensor, PondPrivateTensor, PondMaskedTensor, PondPrivateVariable
 from .pond import TFEVariable, TFETensor, TFEInputter
 from .pond import _type
 from .pond import AdditiveFIFOQueue
@@ -14,6 +14,7 @@ __all__ = [
     "PondTensor",
     "PondPublicTensor",
     "PondPrivateTensor",
+    "PondPrivateVariable",
     "PondMaskedTensor",
     "TFEVariable",
     "TFETensor",


### PR DESCRIPTION
Hey,

Until now we had to `set_weights` under `with tf.Session() as sess:` or pass explicitly a TFE session. However ideally we would like to be able to `set_weights` outside this context to get the same behavior as Keras:

```
model = tf.keras.models.Sequential()
model.add(tf.keras.layers.Dense(5, use_bias=False, input_shape=[5]))
model.set_weights([np.ones([5, 5])])
y = model(x)

with K.get_session() as sess:
    sess.run(y)
```

This PR is a potential solution but it's not perfect. Ideally we would like to have something like `K.get_session()` which would create a tfe.Session() when it doesn't exist. Currently to have tfe.Session() from `K.get_session()`, it has to be previously set with `K.set_session(sess)`.

Thanks,

