### PR TITLE
Local computation decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The following is an example of simple matmul on encrypted data using TF Encrypte
 import tensorflow as tf
 import tf_encrypted as tfe
 
+@tfe.local_computation('input-provider')
 def provide_input():
     # normal TensorFlow operations can be run locally
     # as part of defining a private input, in this
@@ -49,7 +50,7 @@ def provide_input():
 
 # define inputs
 w = tfe.define_private_variable(tf.ones(shape=(10,10)))
-x = tfe.define_private_input('input-provider', provide_input)
+x = provide_input()
 
 # define computation
 y = tfe.matmul(x, w)

--- a/examples/federated-learning/run.py
+++ b/examples/federated-learning/run.py
@@ -118,7 +118,7 @@ class ModelOwner:
         print_loss = tf.print("loss", loss)
         print_expected = tf.print("expect", y, summarize=50)
         print_result = tf.print("result", y_hat, summarize=50)
-        return print_loss, print_expected, print_result
+        return tf.group(print_loss, print_expected, print_result)
 
 
 class DataOwner:

--- a/examples/logistic/common.py
+++ b/examples/logistic/common.py
@@ -1,7 +1,7 @@
 """Provide classes to perform private training and private prediction with
 logistic regression"""
 import tensorflow as tf
-# pylint:  disable=redefined-outer-name
+# pylint: disable=redefined-outer-name
 import tf_encrypted as tfe
 
 
@@ -94,6 +94,7 @@ class DataOwner:
   def initializer(self):
     return tf.group(self.train_initializer, self.test_initializer)
 
+  @tfe.local_computation
   def provide_training_data(self):
     """Preprocess training dataset
 
@@ -124,6 +125,7 @@ class DataOwner:
 
     return x, y
 
+  @tfe.local_computation
   def provide_testing_data(self):
     """Preprocess testing dataset
 
@@ -158,6 +160,7 @@ class ModelOwner:
   def __init__(self, player_name):
     self.player_name = player_name
 
+  @tfe.local_computation
   def receive_weights(self, *weights):
     return tf.print("Weights on {}:".format(self.player_name), weights)
 
@@ -168,6 +171,7 @@ class PredictionClient:
     self.player_name = player_name
     self.num_features = num_features
 
+  @tfe.local_computation
   def provide_input(self):
     return tf.random.uniform(
         minval=-.5,
@@ -175,5 +179,6 @@ class PredictionClient:
         dtype=tf.float32,
         shape=[1, self.num_features])
 
+  @tfe.local_computation
   def receive_output(self, result):
     return tf.print("Result on {}:".format(self.player_name), result)

--- a/examples/logistic/common.py
+++ b/examples/logistic/common.py
@@ -1,7 +1,6 @@
 """Provide classes to perform private training and private prediction with
 logistic regression"""
 import tensorflow as tf
-# pylint: disable=redefined-outer-name
 import tf_encrypted as tfe
 
 

--- a/examples/logistic/prediction_joint.py
+++ b/examples/logistic/prediction_joint.py
@@ -10,17 +10,14 @@ prediction_client_0 = PredictionClient('prediction-client-0', num_features // 2)
 prediction_client_1 = PredictionClient('prediction-client-1', num_features // 2)
 result_receiver = prediction_client_0
 
-x_0 = tfe.define_private_input(prediction_client_0.player_name,
-                               prediction_client_0.provide_input)
-x_1 = tfe.define_private_input(prediction_client_1.player_name,
-                               prediction_client_1.provide_input)
+x_0 = prediction_client_0.provide_input()
+x_1 = prediction_client_0.provide_input()
 x = tfe.concat([x_0, x_1], axis=1)
 
 y = model.forward(x)
 
-reveal_output = tfe.define_output(result_receiver.player_name,
-                                  y,
-                                  result_receiver.receive_output)
+
+reveal_output = result_receiver.receive_output(y)
 
 with tfe.Session() as sess:
   sess.run(tfe.global_variables_initializer(), tag='init')

--- a/examples/logistic/prediction_joint.py
+++ b/examples/logistic/prediction_joint.py
@@ -11,7 +11,7 @@ prediction_client_1 = PredictionClient('prediction-client-1', num_features // 2)
 result_receiver = prediction_client_0
 
 x_0 = prediction_client_0.provide_input()
-x_1 = prediction_client_0.provide_input()
+x_1 = prediction_client_1.provide_input()
 x = tfe.concat([x_0, x_1], axis=1)
 
 y = model.forward(x)

--- a/examples/logistic/prediction_single.py
+++ b/examples/logistic/prediction_single.py
@@ -8,14 +8,11 @@ num_features = 10
 model = LogisticRegression(num_features)
 prediction_client = PredictionClient('prediction-client', num_features)
 
-x = tfe.define_private_input(prediction_client.player_name,
-                             prediction_client.provide_input)
+x = prediction_client.provide_input()
 
 y = model.forward(x)
 
-reveal_output = tfe.define_output(prediction_client.player_name,
-                                  y,
-                                  prediction_client.receive_output)
+reveal_output = prediction_client.receive_output(y)
 
 with tfe.Session() as sess:
   sess.run(tfe.global_variables_initializer(), tag='init')

--- a/examples/logistic/training_joint.py
+++ b/examples/logistic/training_joint.py
@@ -26,27 +26,17 @@ tfe.set_protocol(tfe.protocol.Pond(
     tfe.get_config().get_player(data_owner_1.player_name)
 ))
 
-x_train_0, y_train_0 = tfe.define_private_input(
-    data_owner_0.player_name,
-    data_owner_0.provide_training_data)
-x_train_1, y_train_1 = tfe.define_private_input(
-    data_owner_1.player_name,
-    data_owner_1.provide_training_data)
+x_train_0, y_train_0 = data_owner_0.provide_training_data()
+x_train_1, y_train_1 = data_owner_1.provide_training_data()
 
-x_test_0, y_test_0 = tfe.define_private_input(
-    data_owner_0.player_name,
-    data_owner_0.provide_testing_data)
-x_test_1, y_test_1 = tfe.define_private_input(
-    data_owner_1.player_name,
-    data_owner_1.provide_testing_data)
+x_test_0, y_test_0 = data_owner_0.provide_testing_data()
+x_test_1, y_test_1 = data_owner_1.provide_testing_data()
 
 x_train = tfe.concat([x_train_0, x_train_1], axis=0)
 y_train = tfe.concat([y_train_0, y_train_1], axis=0)
 
 model = LogisticRegression(num_features)
-reveal_weights_op = tfe.define_output(
-    model_owner.player_name, model.weights,
-    model_owner.receive_weights)
+reveal_weights_op = model_owner.receive_weights(model.weights)
 
 with tfe.Session() as sess:
   sess.run([tfe.global_variables_initializer(),

--- a/examples/logistic/training_single.py
+++ b/examples/logistic/training_single.py
@@ -17,17 +17,10 @@ data_owner = DataOwner('data-owner',
                        test_set_size,
                        batch_size)
 
-x_train, y_train = tfe.define_private_input(
-    data_owner.player_name,
-    data_owner.provide_training_data)
-x_test, y_test = tfe.define_private_input(
-    data_owner.player_name,
-    data_owner.provide_testing_data)
+x_train, y_train = data_owner.provide_training_data()
+x_test, y_test = data_owner.provide_testing_data()
 
-reveal_weights_op = tfe.define_output(
-    model_owner.player_name,
-    model.weights,
-    model_owner.receive_weights)
+reveal_weights_op = model_owner.receive_weights(model.weights)
 
 with tfe.Session() as sess:
   sess.run([tfe.global_variables_initializer(),

--- a/examples/simple-average/run.py
+++ b/examples/simple-average/run.py
@@ -14,12 +14,12 @@ if len(sys.argv) >= 2:
   tfe.set_config(config)
   tfe.set_protocol(tfe.protocol.Pond())
 
-@tfe.local_computation
+@tfe.local_computation(name_scope='provide_input')
 def provide_input() -> tf.Tensor:
   # pick random tensor to be averaged
   return tf.random_normal(shape=(10,))
 
-@tfe.local_computation('result-receiver')
+@tfe.local_computation('result-receiver', name_scope='receive_output')
 def receive_output(average: tf.Tensor) -> tf.Operation:
   # simply print average
   return tf.print("Average:", average)
@@ -27,8 +27,13 @@ def receive_output(average: tf.Tensor) -> tf.Operation:
 
 if __name__ == '__main__':
   # get input from inputters as private values
-  inputs = [provide_input(player_name="inputter-{}".format(i))  # pylint: disable=unexpected-keyword-arg
-            for i in range(5)]
+  inputs = [
+      provide_input(player_name='inputter-0'),  # pylint: disable=unexpected-keyword-arg
+      provide_input(player_name='inputter-1'),  # pylint: disable=unexpected-keyword-arg
+      provide_input(player_name='inputter-2'),  # pylint: disable=unexpected-keyword-arg
+      provide_input(player_name='inputter-3'),  # pylint: disable=unexpected-keyword-arg
+      provide_input(player_name='inputter-4'),  # pylint: disable=unexpected-keyword-arg
+  ]
 
   # sum all inputs and divide by count
   result = tfe.add_n(inputs) / len(inputs)

--- a/tf_encrypted/convert/README.md
+++ b/tf_encrypted/convert/README.md
@@ -16,6 +16,7 @@ The following name scopes are reserved for use by the TF Encrypted Converter.  I
 
 Reserved Scope | TF Counterpart
 ---------------|---------------
+`batch_normalization_v1`|[tf.keras.layers.BatchNormalization](https://www.tensorflow.org/api_docs/python/tf/keras/layers/BatchNormalization)
 `conv2d`|[tf.keras.layers.Conv2D](https://www.tensorflow.org/api_docs/python/tf/keras/layers/Conv2D)
 `dense`|[tf.keras.layers.Dense](https://www.tensorflow.org/api_docs/python/tf/keras/layers/Dense)
 `flatten`|[tf.keras.layers.Flatten](https://www.tensorflow.org/api_docs/python/tf/keras/layers/Flatten)

--- a/tf_encrypted/protocol/pond/pond.py
+++ b/tf_encrypted/protocol/pond/pond.py
@@ -520,25 +520,9 @@ class Pond(Protocol):
                            "function, or as an argument to the "
                            "tfe.local_computation decorator.")
 
-        def result_guard(*args, **kwargs):
-          output = compute_func(*args, **kwargs)
-
-          # wrap in tf.group to prevent sending back any tensors (which might
-          # hence be leaked)
-          is_op = tf.contrib.framework.nest.flatten(
-              tf.contrib.framework.nest.map_structure(
-                  lambda x: isinstance(x, tf.Operation),
-                  output,
-              )
-          )
-          if all(is_op):
-            return tf.group(output)
-
-          return output
-
         return self.define_local_computation(
             actual_player_name,
-            result_guard,
+            compute_func,
             arguments=compute_func_args,
             **kwargs,
         )

--- a/tf_encrypted/protocol/pond/pond.py
+++ b/tf_encrypted/protocol/pond/pond.py
@@ -439,6 +439,119 @@ class Pond(Protocol):
         raise TypeError(("Don't know how to handle inputs "
                          "of type {}").format(type(inputs)))
 
+  def local_computation(
+      self,
+      player_name=None,
+      **kwargs):
+    """Annotate a function `compute_func` for local computation.
+
+    This decorator can be used to pin a function's code to a specific player's
+    device for remote execution.  This is useful when defining player-specific
+    handlers for e.g. providing model weights, or input and output tensors.
+
+    The decorator can handle global functions, normal object methods, or
+    classmethods. If wrapping a method, it's presumed that the method's object
+    has an attribute named `player_name`, or that the user will provide the
+    `player_name` later on as a kwarg to the `compute_func`.
+
+    Example:
+      ```
+      @tfe.local_computation('input-provider')
+      def provide_input():
+        return tf.random.normal((3, 3))
+
+      @tfe.local_computation
+      def receive_output(logits):
+        return tf.print(tf.argmax(logits, axis=-1))
+
+      x = provide_input()
+      y = model(x)
+      receive_op = receive_output(y, player_name='output-receiver')
+      with tfe.Session():
+        sess.run(receive_op)
+      ```
+
+    Arguments:
+      player_name: Name of the player who should execute the function.
+      kwargs: Keyword arguments to use when encoding or encrypting
+        inputs/outputs to compute_func: see tfe.define_local_computation for
+        details.
+
+    Returns:
+      The compute_func, but decorated for remote execution.
+    """
+    if callable(player_name):
+      # The user has called us as a standard decorator:
+      #
+      # @tfe.local_computation
+      # def provide_input():
+      #   return tf.zeros((2, 2))
+      actual_compute_func = player_name
+      player_name = None
+    else:
+      # The user has called us as a function, maybe with non-default args:
+      #
+      # @tfe.local_computation('input-provider')
+      # def provide_input():
+      #   return tf.zeros((2, 2))
+      actual_compute_func = None
+
+    def decorator(compute_func):
+
+      @wraps(compute_func)
+      def compute_func_wrapper(*compute_func_args, **compute_func_kwargs):
+
+        # Assumer user has passed player_name to decorator. If not, try to recover.
+        actual_player_name = player_name
+        if actual_player_name is None:
+          # Maybe user has passed player_name to compute_func as a kwarg
+          actual_player_name = compute_func_kwargs.get("player_name", None)
+        if actual_player_name is None:
+          # Assume compute_func is a method and its instance has some attribute
+          # 'player_name'
+          if compute_func_args:
+            parent_instance = compute_func_args[0]
+            actual_player_name = getattr(parent_instance, 'player_name', None)
+        if actual_player_name is None:
+          # Fallback to error
+          raise ValueError("'player_name' not provided. Please provide "
+                           "'player_name' as a keyword argument to this "
+                           "function, or as an argument to the "
+                           "tfe.local_computation decorator.")
+
+        def result_guard(*args, **kwargs):
+          output = compute_func(*args, **kwargs)
+
+          # wrap in tf.group to prevent sending back any tensors (which might
+          # hence be leaked)
+          is_op = tf.contrib.framework.nest.flatten(
+              tf.contrib.framework.nest.map_structure(
+                  lambda x: isinstance(x, tf.Operation),
+                  output,
+              )
+          )
+          if all(is_op):
+            return tf.group(output)
+
+          return output
+
+        return self.define_local_computation(
+            actual_player_name,
+            result_guard,
+            arguments=compute_func_args,
+            **kwargs,
+        )
+
+      return compute_func_wrapper
+
+    if actual_compute_func is None:
+      # User has not yet passed a compute_func, so we'll expect them to
+      # pass it outside of this function's scope (e.g. as a decorator).
+      return decorator
+
+    # User has already passed a compute_func, so return the decorated version.
+    return decorator(actual_compute_func)
+
   def define_local_computation(
       self,
       player,

--- a/tf_encrypted/protocol/pond/pond.py
+++ b/tf_encrypted/protocol/pond/pond.py
@@ -6,11 +6,11 @@ helper."""
 from __future__ import absolute_import
 from typing import Tuple, List, Union, Optional, Any, NewType, Callable
 import abc
-import sys
+from functools import reduce, wraps
 import logging
 from math import log2, ceil
 import random
-from functools import reduce
+import sys
 
 import numpy as np
 import tensorflow as tf

--- a/tf_encrypted/protocol/pond/pond.py
+++ b/tf_encrypted/protocol/pond/pond.py
@@ -488,7 +488,7 @@ class Pond(Protocol):
 
     def reconstruct_input(x):
 
-      if isinstance(x, tf.Tensor):
+      if not isinstance(x, (AbstractTensor, PondTensor)):
         return x
 
       if isinstance(x, PondPublicTensor):
@@ -520,7 +520,8 @@ class Pond(Protocol):
           if not isinstance(arguments, (list, tuple)):
             arguments = [arguments]
 
-          inputs = [reconstruct_input(x) for x in arguments]
+          inputs = tf.contrib.framework.nest.map_structure(
+              reconstruct_input, arguments)
 
         outputs = computation_fn(*inputs)
 
@@ -1982,7 +1983,7 @@ class PondPrivateVariable(PondPrivateTensor):
     assert variable0.shape == variable1.shape
 
     super(PondPrivateVariable, self).__init__(
-        prot, variable0, variable1, is_scaled
+        prot, variable0, variable1, is_scaled,
     )
     self.variable0 = variable0
     self.variable1 = variable1


### PR DESCRIPTION
Adds a `local_computation` decorator that wraps up functions in a call to `define_local_computation`. See examples for usage.

Other small fixes:
- Small style fixes
- Changed the way metrics are reported in the secure aggregation example.
- For reconstruct_input in tfe.define_local_computation, use tf.contrib.framework.nest when dealing with iterables of tensors. Planning to open an issue to standardize this pattern across the project.