### PR TITLE
fix: set_weights inputs shapes match layer weights shapes

### DIFF
--- a/tf_encrypted/keras/engine/base_layer.py
+++ b/tf_encrypted/keras/engine/base_layer.py
@@ -135,7 +135,8 @@ class Layer(ABC):
         sess.run(tfe.assign(w, tfe_weights_pl), feed_dict=fd)
     elif isinstance(weights[0], PondPrivateTensor):
       for i, w in enumerate(self.weights):
-        sess.run(tfe.assign(w, weights[i]))
+        shape = w.shape.as_list()
+        sess.run(tfe.assign(w, weights[i].reshape(shape)))
 
   @property
   def prot(self):


### PR DESCRIPTION
Hey @mortendahl, 

This is is a small pr to fix @VMS-6511 issue in pr #599. The bias for conv2d is of rank 3 (e.g. [16, 1, 1]) in TFE. By default, the bias pass in `set_weights` is of rank 1 (e.g ([16]). This reshape just expand the tensor to rank 3 (e.g. [16, 1, 1]).

Thanks