### PR TITLE
Increase tests atol

### DIFF
--- a/tf_encrypted/keras/layers/depthwise_conv_test.py
+++ b/tf_encrypted/keras/layers/depthwise_conv_test.py
@@ -54,7 +54,8 @@ class TestDepthwiseConv2d(unittest.TestCase):
     kwargs = {**base_kwargs, **layer_kwargs}
     agreement_test(tfe.keras.layers.DepthwiseConv2D,
                    kwargs=kwargs,
-                   input_shape=input_shape)
+                   input_shape=input_shape,
+                   atol=1e-2)
     layer_test(tfe.keras.layers.DepthwiseConv2D,
                kwargs=kwargs,
                batch_input_shape=input_shape)

--- a/tf_encrypted/keras/layers/depthwise_conv_test.py
+++ b/tf_encrypted/keras/layers/depthwise_conv_test.py
@@ -55,7 +55,7 @@ class TestDepthwiseConv2d(unittest.TestCase):
     agreement_test(tfe.keras.layers.DepthwiseConv2D,
                    kwargs=kwargs,
                    input_shape=input_shape,
-                   atol=1e-2)
+                   atol=1e-3)
     layer_test(tfe.keras.layers.DepthwiseConv2D,
                kwargs=kwargs,
                batch_input_shape=input_shape)

--- a/tf_encrypted/keras/models/sequential_test.py
+++ b/tf_encrypted/keras/models/sequential_test.py
@@ -46,7 +46,7 @@ class TestSequential(unittest.TestCase):
     with KE.get_session() as sess:
       actual = sess.run(y.reveal())
 
-      np.testing.assert_allclose(actual, expected, rtol=1e-2, atol=1e-4)
+      np.testing.assert_allclose(actual, expected, rtol=1e-2, atol=1e-3)
 
     KE.clear_session()
 
@@ -68,7 +68,7 @@ class TestSequential(unittest.TestCase):
     with KE.get_session() as sess:
       actual = sess.run(y.reveal())
 
-      np.testing.assert_allclose(actual, expected, rtol=1e-2, atol=1e-4)
+      np.testing.assert_allclose(actual, expected, rtol=1e-2, atol=1e-3)
 
     KE.clear_session()
 
@@ -92,7 +92,7 @@ class TestSequential(unittest.TestCase):
       y = tfe_model(x)
       actual = sess.run(y.reveal())
 
-      np.testing.assert_allclose(actual, expected, rtol=1e-2, atol=1e-4)
+      np.testing.assert_allclose(actual, expected, rtol=1e-2, atol=1e-3)
 
     KE.clear_session()
 
@@ -119,7 +119,7 @@ class TestSequential(unittest.TestCase):
 
         actual = sess.run(y.reveal())
 
-        np.testing.assert_allclose(actual, expected, rtol=1e-2, atol=1e-4)
+        np.testing.assert_allclose(actual, expected, rtol=1e-2, atol=1e-3)
 
 
   def test_conv_model(self):


### PR DESCRIPTION
`atol=1e-4` seemed too conservative, causing tests to frequently fail. This PR raises the tolerance to `atol=1e-3`.