### PR TITLE
Added converter support for DepthwiseConv2D

### DIFF
--- a/tf_encrypted/convert/convert.py
+++ b/tf_encrypted/convert/convert.py
@@ -286,7 +286,7 @@ def match_numbered_scope(specop, search_string, return_group=True):
 
   Example: 'conv2d' will match '...conv2d_345/...' and return 'conv2d_345'.
   """
-  expr = '({0})/|({0}_[0-9]+)/'.format(specop)
+  expr = '(^{0})/|(^{0}_[0-9]+)/'.format(specop)
   match = re.search(expr, search_string)
   if match is not None:
     if not return_group:
@@ -303,7 +303,7 @@ def match_numbered_leaf(leaf_to_match, search_string):
 
   Example: 'Conv2D' will match '.../Conv2D_5' and return 'Conv2D_5'
   """
-  expr = '/({0})|/({0}_[0-9]+)'.format(leaf_to_match)
+  expr = '/({0}$)|/({0}_[0-9]+$)'.format(leaf_to_match)
   match = re.search(expr, search_string)
   if match is not None:
     return match.group(1)

--- a/tf_encrypted/convert/convert_test.py
+++ b/tf_encrypted/convert/convert_test.py
@@ -269,7 +269,7 @@ class TestConvert(unittest.TestCase):
   def test_keras_depthwise_conv2d_convert(self):
     test_input = np.ones([1, 8, 8, 1])
     self._test_with_ndarray_input_fn(
-      'keras_depthwise_conv2d', test_input, protocol='Pond')
+        'keras_depthwise_conv2d', test_input, protocol='Pond')
 
   def test_keras_dense_convert(self):
     test_input = np.ones([2, 10])
@@ -874,9 +874,9 @@ def _keras_depthwise_conv2d_core(shape=None, data=None):
 
   model = Sequential()
   c2d = DepthwiseConv2D((3, 3),
-               data_format="channels_last",
-               use_bias=False,
-               input_shape=shape[1:])
+                        data_format="channels_last",
+                        use_bias=False,
+                        input_shape=shape[1:])
   model.add(c2d)
 
   if data is None:

--- a/tf_encrypted/convert/specops.yaml
+++ b/tf_encrypted/convert/specops.yaml
@@ -38,3 +38,12 @@ batch_normalization_v1:
     tf.keras.layers.BatchNormalization
   hyperlink:
     https://www.tensorflow.org/api_docs/python/tf/keras/layers/BatchNormalization
+depthwise_conv2d:
+  interiors:
+  - depthwise
+  - depthwise_kernel
+  - bias
+  tf-name:
+    tf.keras.layers.DepthwiseConv2D
+  hyperlink:
+    https://www.tensorflow.org/api_docs/python/tf/keras/layers/DepthwiseConv2D


### PR DESCRIPTION
Added converter support the DepthwiseConv2D.
Two changes were made in converter.py - 
1. Added '^' to the regex in ```match_numbered_scope``` - this was needed because when looking for special ops, the ```depthwise_conv2d``` node matched to ```conv2d``` op. 

2. added '$' to the regex in ```match_numbered_leaf``` - this was needed because when looking for the interiors of the depthwise conv layer the ```depthwise``` op matched the ```depthwise_conv2d/depthwise_kernel``` node. 