### PR TITLE
Fix issues with running on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,5 +327,7 @@ clean:
 	rm -f $(LIBSODIUM_VER_TAG).tar.gz
 	find ./tf_encrypted/operations -name '*.so' -delete
 
+clean-pycache:
+	find . | grep -E "(__pycache__|\.pyc|\.pyo$)" | xargs rm -rf
 
-.PHONY: clean
+.PHONY: clean clean-pycache

--- a/tf_encrypted/protocol/pond/pond.py
+++ b/tf_encrypted/protocol/pond/pond.py
@@ -722,7 +722,7 @@ class Pond(Protocol):
       # and then we round to integers
 
       if isinstance(scaled, np.ndarray):
-        integers = scaled.astype(int).astype(object)
+        integers = scaled.astype(np.int64)
 
       elif isinstance(scaled, tf.Tensor):
         tf_int_type = tf_int_type or (scaled.dtype

--- a/tf_encrypted/protocol/pond/pond_test.py
+++ b/tf_encrypted/protocol/pond/pond_test.py
@@ -10,6 +10,21 @@ from tf_encrypted.tensor import int64factory, int100factory, native_factory
 from tf_encrypted.tensor import fixed100, fixed100_ni
 
 
+class TestPond(unittest.TestCase):
+
+  def test_encode(self):
+
+    with tf.Graph().as_default():
+      prot = tfe.protocol.Pond()
+
+      expected = np.array([1234567.9875])
+      x = prot.define_constant(expected)
+
+      with tfe.Session() as sess:
+        actual = sess.run(x)
+        np.testing.assert_array_almost_equal(actual, expected, decimal=3)
+
+
 class TestTruncate(unittest.TestCase):
   def setUp(self):
     tf.reset_default_graph()

--- a/tf_encrypted/tensor/int100.py
+++ b/tf_encrypted/tensor/int100.py
@@ -64,7 +64,7 @@ def crt_factory(INT_TYPE, MODULI):  # pylint: disable=invalid-name
     def crt_recombine_explicit(x, bound):
 
       big_b = MODULUS % bound
-      b = [(MODULUS // mi) % bound for mi in MODULI]
+      b = [np.array([(MODULUS // mi) % bound], dtype=np.int64) for mi in MODULI]
 
       with tf.name_scope('crt_recombine_explicit'):
 


### PR DESCRIPTION
See tf-encrypted#577 for more details. Basic problem is that `int` is interpreted differently on Windows (32bits) and macOS (64 bits), so make sure to explicitly used `int64`.