### PR TITLE
Fix Keras example notebooks

### DIFF
--- a/examples/notebooks/keras-classification/a - Secure Classification with TFE Keras - Public Training.ipynb
+++ b/examples/notebooks/keras-classification/a - Secure Classification with TFE Keras - Public Training.ipynb
@@ -11,16 +11,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/anaconda3/envs/py35_int64/lib/python3.5/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.\n",
-      "  from ._conv import register_converters as _register_converters\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from __future__ import print_function\n",
     "import tensorflow.keras as keras\n",
@@ -43,19 +34,19 @@
       "x_train shape: (60000, 28, 28, 1)\n",
       "60000 train samples\n",
       "10000 test samples\n",
-      "WARNING:tensorflow:From /anaconda3/envs/py35_int64/lib/python3.5/site-packages/tensorflow/python/ops/resource_variable_ops.py:435: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
+      "WARNING:tensorflow:From /home/jason/anaconda3/envs/tf-encrypted/lib/python3.5/site-packages/tensorflow/python/ops/resource_variable_ops.py:435: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
       "Instructions for updating:\n",
       "Colocations handled automatically by placer.\n",
       "Train on 60000 samples, validate on 10000 samples\n",
-      "WARNING:tensorflow:From /anaconda3/envs/py35_int64/lib/python3.5/site-packages/tensorflow/python/ops/math_ops.py:3066: to_int32 (from tensorflow.python.ops.math_ops) is deprecated and will be removed in a future version.\n",
+      "WARNING:tensorflow:From /home/jason/anaconda3/envs/tf-encrypted/lib/python3.5/site-packages/tensorflow/python/ops/math_ops.py:3066: to_int32 (from tensorflow.python.ops.math_ops) is deprecated and will be removed in a future version.\n",
       "Instructions for updating:\n",
       "Use tf.cast instead.\n",
       "Epoch 1/2\n",
-      "60000/60000 [==============================] - 1s 14us/sample - loss: 0.3887 - acc: 0.8936 - val_loss: 0.2257 - val_acc: 0.9360\n",
+      "60000/60000 [==============================] - 1s 23us/sample - loss: 0.4056 - acc: 0.8874 - val_loss: 0.2403 - val_acc: 0.9320\n",
       "Epoch 2/2\n",
-      "60000/60000 [==============================] - 1s 12us/sample - loss: 0.2063 - acc: 0.9405 - val_loss: 0.1700 - val_acc: 0.9499\n",
-      "Test loss: 0.16998537007272244\n",
-      "Test accuracy: 0.9499\n"
+      "60000/60000 [==============================] - 1s 22us/sample - loss: 0.2164 - acc: 0.9374 - val_loss: 0.1855 - val_acc: 0.9449\n",
+      "Test loss: 0.18545715087205172\n",
+      "Test accuracy: 0.9449\n"
      ]
     }
    ],
@@ -133,7 +124,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.5.6"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/keras-classification/b - Secure Classification with TFE Keras - Secure Model Serving .ipynb
+++ b/examples/notebooks/keras-classification/b - Secure Classification with TFE Keras - Secure Model Serving .ipynb
@@ -16,20 +16,18 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/anaconda3/envs/py35_int64/lib/python3.5/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.\n",
-      "  from ._conv import register_converters as _register_converters\n",
-      "WARNING:tf_encrypted:Falling back to insecure randomness since the required custom op could not be found for the installed version of TensorFlow (1.13.1). Fix this by compiling custom ops.\n"
+      "WARNING:tf_encrypted:Falling back to insecure randomness since the required custom op could not be found for the installed version of TensorFlow. Fix this by compiling custom ops. Missing file was '/home/jason/tf-encrypted/tf_encrypted/operations/secure_random/secure_random_module_tf_1.13.1.so'\n"
      ]
     }
    ],
    "source": [
     "import numpy as np\n",
     "import tensorflow as tf\n",
-    "from tensorflow.keras import backend as K\n",
     "from tensorflow.keras import Sequential\n",
     "from tensorflow.keras.layers import AveragePooling2D, Conv2D, Dense, Activation, Flatten, ReLU, Activation\n",
     "\n",
     "import tf_encrypted as tfe\n",
+    "import tf_encrypted.keras.backend as KE\n",
     "\n",
     "from collections import OrderedDict"
    ]
@@ -60,7 +58,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WARNING:tensorflow:From /anaconda3/envs/py35_int64/lib/python3.5/site-packages/tensorflow/python/ops/resource_variable_ops.py:435: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
+      "WARNING:tensorflow:From /home/jason/anaconda3/envs/tf-encrypted/lib/python3.5/site-packages/tensorflow/python/ops/resource_variable_ops.py:435: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
       "Instructions for updating:\n",
       "Colocations handled automatically by placer.\n"
      ]
@@ -69,7 +67,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "WARNING:tensorflow:From /anaconda3/envs/py35_int64/lib/python3.5/site-packages/tensorflow/python/ops/resource_variable_ops.py:435: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
+      "WARNING:tensorflow:From /home/jason/anaconda3/envs/tf-encrypted/lib/python3.5/site-packages/tensorflow/python/ops/resource_variable_ops.py:435: colocate_with (from tensorflow.python.framework.ops) is deprecated and will be removed in a future version.\n",
       "Instructions for updating:\n",
       "Colocations handled automatically by placer.\n"
      ]
@@ -218,7 +216,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sess = K.get_session()"
+    "sess = KE.get_session()"
    ]
   },
   {
@@ -267,7 +265,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.5.6"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/keras-classification/c - Secure Classification with TFE Keras - Private Prediction Client.ipynb
+++ b/examples/notebooks/keras-classification/c - Secure Classification with TFE Keras - Private Prediction Client.ipynb
@@ -16,9 +16,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/anaconda3/envs/py35_int64/lib/python3.5/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.\n",
-      "  from ._conv import register_converters as _register_converters\n",
-      "WARNING:tf_encrypted:Falling back to insecure randomness since the required custom op could not be found for the installed version of TensorFlow (1.13.1). Fix this by compiling custom ops.\n"
+      "WARNING:tf_encrypted:Falling back to insecure randomness since the required custom op could not be found for the installed version of TensorFlow. Fix this by compiling custom ops. Missing file was '/home/jason/tf-encrypted/tf_encrypted/operations/secure_random/secure_random_module_tf_1.13.1.so'\n"
      ]
     }
    ],
@@ -176,7 +174,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.4"
+   "version": "3.5.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #638 

The Keras example notebooks had not been updated with our implementation of `tfe.keras.backend`, so this PR updates them.