### PR TITLE
Fixed bugs in converter

### DIFF
--- a/tf_encrypted/convert/convert.py
+++ b/tf_encrypted/convert/convert.py
@@ -288,16 +288,19 @@ def find_leaves(scope, subscope_map):
 
 def match_numbered_scope(specop, search_string,
                          return_group=True,
-                         numbered=True
-                         ):
+                         numbered=True):
   """
   Find a numbered scope matching a specop from REGISTERED_SPECOPS,
   and return it if found.
     Example: 'conv2d' will match '...conv2d_345/...' and return 'conv2d_345'.
 
   Args:
+    specop: the specop to match.
+    search_string: the op name to search.
+    return group: if True, returns the last matching group, otherwise return
+        the match object.
     numbered: only match exact numbering  -
-            i.e. conv2d_1 will only match conv2d_1 and not conv2d etc.
+        i.e. conv2d_1 will only match conv2d_1 and not conv2d etc.
 
   """
   if numbered:

--- a/tf_encrypted/convert/convert.py
+++ b/tf_encrypted/convert/convert.py
@@ -94,7 +94,9 @@ class Converter:
         # Register high level special operations
         for s in specop_dict:
           # If this node is the output of the current specop, register it
-          if match_numbered_scope(s, node.name, return_group=False, not_numbered=True):
+          if match_numbered_scope(s, node.name,
+                                  return_group=False,
+                                  not_numbered=True):
             self._register_specop(node, specop_dict[s])
 
     return self.outputs[graph_def.node[-1].name]
@@ -284,7 +286,9 @@ def find_leaves(scope, subscope_map):
   return input_leaves, output_leaves
 
 
-def match_numbered_scope(specop, search_string, return_group=True, not_numbered=False):
+def match_numbered_scope(specop, search_string,
+                         return_group=True,
+                         not_numbered=False):
   """
   Find a numbered scope matching a specop from REGISTERED_SPECOPS,
   and return it if found

--- a/tf_encrypted/convert/convert.py
+++ b/tf_encrypted/convert/convert.py
@@ -96,7 +96,7 @@ class Converter:
           # If this node is the output of the current specop, register it
           if match_numbered_scope(s, node.name,
                                   return_group=False,
-                                  not_numbered=True):
+                                  numbered=False):
             self._register_specop(node, specop_dict[s])
 
     return self.outputs[graph_def.node[-1].name]
@@ -288,20 +288,22 @@ def find_leaves(scope, subscope_map):
 
 def match_numbered_scope(specop, search_string,
                          return_group=True,
-                         not_numbered=False):
+                         numbered=True
+                         ):
   """
   Find a numbered scope matching a specop from REGISTERED_SPECOPS,
-  and return it if found
+  and return it if found.
+    Example: 'conv2d' will match '...conv2d_345/...' and return 'conv2d_345'.
 
-  :param not_numbered: only match exact numbering  -
-  i.e. conv2d_1 will only match conv2d_1 and not conv2d etc.
+  Args:
+    numbered: only match exact numbering  -
+            i.e. conv2d_1 will only match conv2d_1 and not conv2d etc.
 
-  Example: 'conv2d' will match '...conv2d_345/...' and return 'conv2d_345'.
   """
-  if not_numbered:
-    expr = '^(.*/)*({0})/'.format(specop)
-  else:
+  if numbered:
     expr = '^(.*/)*({0})/|(^(.*/)*({0}_[0-9]+))/'.format(specop)
+  else:
+    expr = '^(.*/)*({0})/'.format(specop)
 
   match = re.search(expr, search_string)
   if match is not None:


### PR DESCRIPTION
Following slack discussion with @jvmancuso I've fixed some bugs in the converter - 

1. In ```match_numbered_scope``` - added argument ```not_numbered``` to only match exact numbering. This was needed because when we had two layers of the same type, for example two batch norm layers, the second node - ```batch_normalization_v1_1``` - matched both nodes in the ```specop_dict``` in the convert method, and we only want to match the same node. 

2. In ```match_numbered_scope``` - changed the regex to match scoped nodes such as ```custom_layer/conv2d/kernel```.

3. In ```match_numbered_scope``` - changed the return mechanism to return the last group which is not none. This was needed because with the new regex, nodes such as ```conv2d_1/kernel``` returned the following groups - ```(None, None, 'conv2d_1', None)``` and this did not match the old return mechanism. 

4. In ```find_leaves``` - added an edge case for the ```batch_normalization_v1/keras_learning_phase``` node. This node serves as input to many other nodes but is irrelevant to the conversion to secure model and therefore was ignored to avoid errors.
