### PR TITLE
Fix edge case when using specific specops in Converter

### DIFF
--- a/tf_encrypted/convert/convert.py
+++ b/tf_encrypted/convert/convert.py
@@ -82,8 +82,8 @@ class Converter:
     # Create a dictionary excluding all the sub ops related to required_space_to_batch_paddings
     # Except the sub ops related to the input or output of this special ops.
     pb_trimmed, graph_def = select_relevant_ops(specop_inputs,
-                                     specop_outputs,
-                                     graph_def)
+                                                specop_outputs,
+                                                graph_def)
     node_list = pb_trimmed.values()
 
     # If the ops are not related to the special ops, use the existing approach to register them.

--- a/tf_encrypted/convert/convert.py
+++ b/tf_encrypted/convert/convert.py
@@ -381,15 +381,13 @@ def find_output_names(graph_def, node_name, num_outputs):
   output_node = [None] * num_outputs
   node_name_list = list(graph_def.keys())
   n_i = node_name_list.index(node_name)
-  #
   # Forward lookahead from the node we want register
   for n in node_name_list[n_i + 1:]:
-
     if not n.startswith(node_name):
       gdf = graph_def[n]
       for x in gdf.input:
-
-        #we insert the names by their index, and not by the order of appearance in the graph
+        # we insert the names by their index,
+        # and not by the order of appearance in the graph
         if x.startswith(node_name):
           if ':' not in x:
             output_node[0] = x

--- a/tf_encrypted/convert/convert_test.py
+++ b/tf_encrypted/convert/convert_test.py
@@ -229,7 +229,9 @@ class TestConvert(unittest.TestCase):
 
   def test_split_edge_case_convert(self):
     test_input = np.random.random([1, 10, 10, 4])
-    self._test_with_ndarray_input_fn('split_edge_case', test_input, protocol='Pond')
+    self._test_with_ndarray_input_fn('split_edge_case',
+                                     test_input,
+                                     protocol='Pond')
 
   def test_split_v_convert(self):
     test_input = np.random.random([1, 10, 10, 3])
@@ -714,8 +716,13 @@ def split_edge_case_builder(input_shape,
                             kernel_size=3):
   x = tf.keras.Input(shape=input_shape[1:])
   y1, y2 = tf.keras.layers.Lambda(
-    lambda tensor: tf.split(tensor, num_or_size_splits=2, axis=-1))(x)
-  y = tf.keras.layers.Conv2D(filters, kernel_size, use_bias=True, padding='same')(y2)
+      lambda tensor: tf.split(tensor,
+                              num_or_size_splits=2,
+                              axis=-1))(x)
+  y = tf.keras.layers.Conv2D(filters,
+                             kernel_size,
+                             use_bias=True,
+                             padding='same')(y2)
   y = tf.keras.layers.Concatenate(axis=-1)([y1, y])
 
   return tf.keras.Model(x, y)

--- a/tf_encrypted/convert/convert_test.py
+++ b/tf_encrypted/convert/convert_test.py
@@ -227,6 +227,10 @@ class TestConvert(unittest.TestCase):
     test_input = np.random.random([1, 10, 10, 3])
     self._test_with_ndarray_input_fn('split', test_input, protocol='Pond')
 
+  def test_split_edge_case_convert(self):
+    test_input = np.random.random([1, 10, 10, 4])
+    self._test_with_ndarray_input_fn('split_edge_case', test_input, protocol='Pond')
+
   def test_split_v_convert(self):
     test_input = np.random.random([1, 10, 10, 3])
     self._test_with_ndarray_input_fn('split_v', test_input, protocol='Pond')
@@ -705,6 +709,28 @@ def export_split(filename, input_shape):
   x = tf.split(a, num_or_size_splits=3, axis=-1)
   return export(x, filename)
 
+def split_edge_case_builder(input_shape,
+                            filters=2,
+                            kernel_size=3):
+  x = tf.keras.Input(shape=input_shape[1:])
+  y1, y2 = tf.keras.layers.Lambda(
+    lambda tensor: tf.split(tensor, num_or_size_splits=2, axis=-1))(x)
+  y = tf.keras.layers.Conv2D(filters, kernel_size, use_bias=True, padding='same')(y2)
+  y = tf.keras.layers.Concatenate(axis=-1)([y1, y])
+
+  return tf.keras.Model(x, y)
+
+def export_split_edge_case(filename, input_shape):
+  model, _ = _keras_model_core(split_edge_case_builder, shape=input_shape)
+
+  sess = K.get_session()
+  output = model.output
+  return export(output, filename, sess=sess)
+
+
+def run_split_edge_case(data):
+  _, out = _keras_model_core(split_edge_case_builder, data=data)
+  return out
 
 def run_split_v(data):
   a = tf.placeholder(tf.float32, shape=data.shape, name="input")


### PR DESCRIPTION
Following slack discussion with @jvmancuso:
Fixed bug in ```find_output_names``` - the problem was that it was searching for names in the trimmed_pb instead of the entire graph. This was not working for a model of the type - 
```
x1, x2 = ChannelSplit()(input_img) #tf.split wrapped as keras layer
x = tf.keras.layers.Conv2D(6, (2,2), use_bias=True, padding='same')(x1)
x = tf.keras.layers.Concatenate(axis=-1)([x2, x])
```
The first output of split was an input to the conv node which is removed in trimmed_pb, and therefore was not found.

This was fixed by searching the original graphdef instead of the trimmed one.

Another change in ```find_output_names``` was to insert the names by their order and not by the order of apperance in the graph. This caused bugs when the second output was used before the first, due to 
https://github.com/tf-encrypted/tf-encrypted/blob/92722ba13c9f536066e6269341ec8963041caef5/tf_encrypted/convert/convert.py#L132-L133