### PR TITLE
Have make bootstrap upgrade pip & gitignore improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,137 @@
 **/.DS_Store
 */.idea/*
 .vscode/**
-
 **/*.pyc
-**/__pycache__/
-.mypy_cache/
-.pytest_cache/
-
-build/
 docs/build
-dist/
 tmp/
 **/*.pb
 data/
-*.egg-info
-*.so
 *.gz
-.cache
 **/.ipynb_checkpoints/
 docs/source/gen
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+**/__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 endif
 
 bootstrap: pythoncheck pipcheck
-	pip intall -U pip
+	pip install -U pip setuptools
 	pip install -r requirements.txt
 	pip install -e .
 	$(MAKE) build

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ endif
 endif
 
 bootstrap: pythoncheck pipcheck
+	pip intall -U pip
 	pip install -r requirements.txt
 	pip install -e .
 	$(MAKE) build


### PR DESCRIPTION
Blocking #656.

- CI was failing because the default pip/setuptools being used was severely outdated
- Also added the standard Python bits to `.gitignore`