### PR TITLE
remove top-level calls to logging.basicConfig()

### DIFF
--- a/examples/bloom/__main__.py
+++ b/examples/bloom/__main__.py
@@ -18,9 +18,7 @@ genebanks = [
     DataOwner("genebank-6", NUM_FEATURES, TRAINING_SET_SIZE, TEST_SET_SIZE),
 ]
 
-logging.basicConfig()
-logger = logging.getLogger("tf_encrypted")
-logger.setLevel(logging.DEBUG)
+logging.basicConfig(level=logging.DEBUG)
 
 model = BloomRegressor()
 model.fit(genebanks)

--- a/examples/bloom/__main__.py
+++ b/examples/bloom/__main__.py
@@ -19,7 +19,7 @@ genebanks = [
 ]
 
 logging.basicConfig()
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("tf_encrypted")
 logger.setLevel(logging.DEBUG)
 
 model = BloomRegressor()

--- a/examples/bloom/__main__.py
+++ b/examples/bloom/__main__.py
@@ -1,4 +1,6 @@
 """Main entrypoint for running Bloom regression example."""
+import logging
+
 import tensorflow as tf
 
 from regressor import BloomRegressor, DataOwner
@@ -15,6 +17,10 @@ genebanks = [
     DataOwner("genebank-5", NUM_FEATURES, TRAINING_SET_SIZE, TEST_SET_SIZE),
     DataOwner("genebank-6", NUM_FEATURES, TRAINING_SET_SIZE, TEST_SET_SIZE),
 ]
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
 model = BloomRegressor()
 model.fit(genebanks)

--- a/examples/federated-learning/run.py
+++ b/examples/federated-learning/run.py
@@ -1,6 +1,7 @@
 """An example of the secure aggregation protocol for federated learning."""
 
 import sys
+import logging
 
 import tensorflow as tf
 import tf_encrypted as tfe
@@ -166,6 +167,10 @@ class DataOwner:
 
 
 if __name__ == "__main__":
+
+  logging.basicConfig()
+  logger = logging.getLogger(__name__)
+  logger.setLevel(logging.DEBUG)
 
   model_owner = ModelOwner("model-owner")
   data_owners = [

--- a/examples/federated-learning/run.py
+++ b/examples/federated-learning/run.py
@@ -169,7 +169,7 @@ class DataOwner:
 if __name__ == "__main__":
 
   logging.basicConfig()
-  logger = logging.getLogger(__name__)
+  logger = logging.getLogger("tf_encrypted")
   logger.setLevel(logging.DEBUG)
 
   model_owner = ModelOwner("model-owner")

--- a/examples/federated-learning/run.py
+++ b/examples/federated-learning/run.py
@@ -168,9 +168,7 @@ class DataOwner:
 
 if __name__ == "__main__":
 
-  logging.basicConfig()
-  logger = logging.getLogger("tf_encrypted")
-  logger.setLevel(logging.DEBUG)
+  logging.basicConfig(level=logging.DEBUG)
 
   model_owner = ModelOwner("model-owner")
   data_owners = [

--- a/examples/mnist/run.py
+++ b/examples/mnist/run.py
@@ -5,6 +5,7 @@ Also performs plaintext training.
 """
 
 import sys
+import logging
 
 import tensorflow as tf
 import tensorflow.keras as keras
@@ -170,6 +171,10 @@ class PredictionClient():
 
 
 if __name__ == "__main__":
+
+  logging.basicConfig()
+  logger = logging.getLogger(__name__)
+  logger.setLevel(logging.DEBUG)
 
   model_owner = ModelOwner(
       player_name="model-owner",

--- a/examples/mnist/run.py
+++ b/examples/mnist/run.py
@@ -172,9 +172,7 @@ class PredictionClient():
 
 if __name__ == "__main__":
 
-  logging.basicConfig()
-  logger = logging.getLogger("tf_encrypted")
-  logger.setLevel(logging.DEBUG)
+  logging.basicConfig(level=logging.DEBUG)
 
   model_owner = ModelOwner(
       player_name="model-owner",

--- a/examples/mnist/run.py
+++ b/examples/mnist/run.py
@@ -173,7 +173,7 @@ class PredictionClient():
 if __name__ == "__main__":
 
   logging.basicConfig()
-  logger = logging.getLogger(__name__)
+  logger = logging.getLogger("tf_encrypted")
   logger.setLevel(logging.DEBUG)
 
   model_owner = ModelOwner(

--- a/examples/simple-average/run.py
+++ b/examples/simple-average/run.py
@@ -1,5 +1,6 @@
 """Example of a simple average using TF Encrypted."""
 
+import logging
 import sys
 
 import tensorflow as tf
@@ -26,6 +27,9 @@ def receive_output(average: tf.Tensor) -> tf.Operation:
 
 
 if __name__ == '__main__':
+
+  logging.basicConfig(level=logging.DEBUG)
+
   # get input from inputters as private values
   inputs = [
       provide_input(player_name='inputter-0'),  # pylint: disable=unexpected-keyword-arg

--- a/tf_encrypted/config.py
+++ b/tf_encrypted/config.py
@@ -11,10 +11,7 @@ from tensorflow.core.protobuf import rewriter_config_pb2
 
 from .player import Player
 
-
-logging.basicConfig()
 logger = logging.getLogger('tf_encrypted')
-logger.setLevel(logging.DEBUG)
 
 
 def tensorflow_supports_int64():

--- a/tf_encrypted/player/__main__.py
+++ b/tf_encrypted/player/__main__.py
@@ -1,7 +1,13 @@
 """Executable for hosting a Player"""
+import logging
+
 from tf_encrypted.config import RemoteConfig
 
 if __name__ == '__main__':
+
+  logging.basicConfig()
+  logger = logging.getLogger(__name__)
+  logger.setLevel(logging.DEBUG)
 
   import argparse
 

--- a/tf_encrypted/player/__main__.py
+++ b/tf_encrypted/player/__main__.py
@@ -6,7 +6,7 @@ from tf_encrypted.config import RemoteConfig
 if __name__ == '__main__':
 
   logging.basicConfig()
-  logger = logging.getLogger(__name__)
+  logger = logging.getLogger("tf_encrypted")
   logger.setLevel(logging.DEBUG)
 
   import argparse

--- a/tf_encrypted/protocol/pond/triple_sources.py
+++ b/tf_encrypted/protocol/pond/triple_sources.py
@@ -10,9 +10,7 @@ from ...config import get_config
 from ...utils import wrap_in_variables, reachable_nodes, unwrap_fetches
 
 
-logging.basicConfig()
 logger = logging.getLogger('tf_encrypted')
-logger.setLevel(logging.DEBUG)
 
 
 class TripleSource(abc.ABC):

--- a/tf_encrypted/session.py
+++ b/tf_encrypted/session.py
@@ -18,9 +18,7 @@ __TENSORBOARD_DIR__ = str(os.getenv('TFE_EVENTS_DIR', '/tmp/tensorboard'))
 
 _run_counter = defaultdict(int)
 
-logging.basicConfig()
 logger = logging.getLogger('tf_encrypted')
-logger.setLevel(logging.DEBUG)
 
 
 class Session(tf.Session):


### PR DESCRIPTION
Currently when calling `import tf_encrypted`, this implies a call to `logging.basicConfig()`. 
This function has the particularity, that only its first invocation is taken into account and any later calls are ignored. 

However, users of tf_encrypted (as for example users of PySyft) would like to be able to set the logging format themselves and not inherit the setting from tf_encrypted. 
Therefore, I propose to remove all top-level calls of `basicConfig()` and move them to the files acting as scripts (directly invoked, or having a section `if name == '__main__.py'`).