### PR TITLE
fix synchronization issue of private assign

### DIFF
--- a/tf_encrypted/protocol/pond/pond.py
+++ b/tf_encrypted/protocol/pond/pond.py
@@ -803,11 +803,13 @@ class Pond(Protocol):
     val0, val1 = value.share0, value.share1
 
     with tf.name_scope("assign"):
+
       # Having this control_dependencies is important in order to avoid that
       # computationally-dependent shares are updated in different pace
       # (e.g., share0 is computed from share1, and we need to make sure that
       # share1 is NOT already updated).
-      with tf.control_dependencies([val0.value, val1.value]):
+      # See https://github.com/tf-encrypted/tf-encrypted/pull/665 for details.
+      with tf.control_dependencies(val0.support + val1.support):
 
         with tf.device(self.server_0.device_name):
           op0 = var0.assign_from_same(val0)


### PR DESCRIPTION
There is a potential synchronization issue in the current library. The problem is due to the fact that the shares of a variable might have computational dependence. Let `s = s0 + s1`, and `s0_next=func(s1)`, `s1_next=func(s0)`. 
What we expect is:
```
s0_next = func(s1) 
s1_next = func(s0)
s0 = s0_next
s1 = s1_next
```
But the current library does not guarantee the two shares are updated at the same pace, hence the following execution trace might happen:
```
s1_next = func(s0)
s1 = s1_next
s0_next = func(s1)
s0 = s0_next
```
Although the current tests and examples have not been trapped by this issue (because two shares normally are independent from each other), it might cause unexpected problem if more sophisticated protocols are implemented in the future (for example, replicate shares the ABY3 protocol). It would be good to do it in the right way to eliminate this potential issue. 

Below is the POC. With the current library, it will output some random number (e.g., `[[-6.2736008e+14]]`). With the fix in this commit, it will (and should) output `[[101.]]`.

```
import tensorflow as tf
import tf_encrypted as tfe
from tf_encrypted import protocol
from tf_encrypted.protocol.pond import PondPrivateTensor

prot = protocol.get_protocol()

def poc(x, y):
    x_shares = x.unwrapped
    y_shares = y.unwrapped
    z_shares = [None, None]

    with tf.name_scope("fabricated_test"):
        # The computation below does NOT have any security guarantee (e.g., both shares of x will be known by both servers).
        # I just use it to show the synchronization issue.
        with tf.device(prot.server_0.device_name):
            z_shares[0] = x_shares[1] + y_shares[1]
        with tf.device(prot.server_1.device_name):
            z_shares[1] = x_shares[0] + y_shares[0]

    return PondPrivateTensor(prot, z_shares[0], z_shares[1], x.is_scaled)

a = tfe.define_private_variable(tf.ones(shape=(1,1)))
b = tfe.define_private_variable(tf.ones(shape=(1,1)))

op = tfe.assign(a, poc(a, b))

with tfe.Session() as sess:
    sess.run(tfe.global_variables_initializer())

    for i in range(100):
        sess.run(op)
    result = sess.run(a.reveal())
    print(result)
```