### PR TITLE
fix buggy implementation in interactive truncation

### DIFF
--- a/tf_encrypted/protocol/pond/pond.py
+++ b/tf_encrypted/protocol/pond/pond.py
@@ -2382,8 +2382,11 @@ def _truncate_private_interactive(
     # assumption that the values originally lie in `[-B, B)`, and will
     # leak private information otherwise
 
+    # 'a + bound' will automatically lift 'bound' by another scaling factor,
+    # so we should first divide bound by the scaling factor if we want to
+    # use this convenient '+' operation.
     bound = prot.fixedpoint_config.bound_double_precision
-    b = a + bound
+    b = a + (bound / scaling_factor)
 
     # next step is for server0 to add a statistical mask to `b`, reveal
     # it to server1, and compute the lower part


### PR DESCRIPTION
The current implementation of interactive truncation is inconsistent with the paper, and might cause both information leakage and computation error.

As mentioned in the code, using `b = a + bound` will automatically lift `bound` by another scaling factor, hence making both `bound` and `b` TRIPLE-precision. This can cause two issues:

- `b` will be out of our intended range, and the security implication of this is unclear.
- The following revealed `c` will be larger than we expect, and might overflow the max int64 number (2^{63}-1), hence becoming negative, and then when we take the modulo `c %  scaling_factor`, it will be wrong. (The tests have not experienced this issue because the number is not big enough.)