### PR TITLE
fix wrong condition for minval and maxval in sample_uniform

### DIFF
--- a/tf_encrypted/tensor/native.py
+++ b/tf_encrypted/tensor/native.py
@@ -84,9 +84,9 @@ def native_factory(NATIVE_TYPE, EXPLICIT_MODULUS=None):  # pylint: disable=inval
                        shape,
                        minval: Optional[int] = None,
                        maxval: Optional[int] = None):
-      minval = minval or self.min
+      minval = self.min if minval is None else minval
       # TODO(Morten) believe this should be native_type.max+1
-      maxval = maxval or self.max
+      maxval = self.max if maxval is None else maxval
 
       if secure_random.supports_seeded_randomness():
         seed = secure_random.secure_seed()


### PR DESCRIPTION
`minval = minval or self.min` (same for maxval) does not give the expected result when `minval=0`.

Below is the POC. It will give a huge  random number instead of one in [0, 2). It's better to fix it instead of migrating this bug into TFE 2.0 :).

```
import tf_encrypted as tfe
from tf_encrypted.tensor import int64factory

x = int64factory.sample_uniform([1], minval=0, maxval=2)
with tfe.Session():
    print(x.to_native().eval())
```