### PR TITLE
fix circleci docker layer caching problem

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,6 @@
 version: 2
 
 variables:
-  docker-caching: &docker-caching
-    setup_remote_docker:
-      docker_layer_caching: true
   bootstrap: &bootstrap
     run:
       name: Bootstrap the environment
@@ -67,7 +64,7 @@ jobs:
       - image: circleci/python:3.5-jessie
     working_directory: ~/repo
     steps:
-      - *docker-caching
+      - setup_remote_docker
       - checkout
       - *restore-cache
       - *bootstrap
@@ -105,7 +102,7 @@ jobs:
       - image: circleci/python:3.5
     working_directory: ~/repo
     steps:
-      - *docker-caching
+      - setup_remote_docker
       - checkout
       - *restore-cache
       - *bootstrap


### PR DESCRIPTION
circleci changed how docker-layer-caching gets handled, the builds just fail now