### PR TITLE
Fix BatchNorm for model cloning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,6 @@ endif
 endif
 
 bootstrap: pythoncheck pipcheck
-	#pip install -U pip setuptools
 	curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 	python get-pip.py
 	pip install -r requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,7 @@ endif
 endif
 
 bootstrap: pythoncheck pipcheck
-	curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-	python get-pip.py
+	pip install -U pip setuptools
 	pip install -r requirements.txt
 	pip install -e .
 	$(MAKE) build

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,9 @@ endif
 endif
 
 bootstrap: pythoncheck pipcheck
-	pip install -U pip setuptools
+	#pip install -U pip setuptools
+	curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+	python get-pip.py
 	pip install -r requirements.txt
 	pip install -e .
 	$(MAKE) build

--- a/tf_encrypted/keras/engine/base_layer.py
+++ b/tf_encrypted/keras/engine/base_layer.py
@@ -9,7 +9,10 @@ import tf_encrypted as tfe
 from tf_encrypted import get_protocol
 from tf_encrypted.keras import backend as KE
 from tf_encrypted.keras.engine.base_layer_utils import unique_object_name
-from tf_encrypted.protocol.pond import PondPrivateTensor, PondMaskedTensor
+from tf_encrypted.protocol.pond import (PondPrivateTensor,
+                                        PondMaskedTensor,
+                                        PondPublicTensor
+                                       )
 
 logger = logging.getLogger('tf_encrypted')
 
@@ -136,15 +139,11 @@ class Layer(ABC):
           tfe_weights_pl = tfe.define_private_placeholder(shape)
           fd = tfe_weights_pl.feed(weights[i].reshape(shape))
           sess.run(tfe.assign(w, tfe_weights_pl), feed_dict=fd)
-        else:
+        elif isinstance(w, PondPublicTensor):
           shape = w.shape.as_list()
           tfe_weights_pl = tfe.define_public_placeholder(shape)
           fd = tfe_weights_pl.feed(weights[i].reshape(shape))
           sess.run(tfe.assign(w, tfe_weights_pl), feed_dict=fd)
-          # shape = w.shape.as_list()
-          # tf_pl = tf.placeholder(tf.float32, shape=shape)
-          # fd = {tf_pl: weights[i].reshape(shape)}
-          # sess.run(tf.assign(w, tf_pl), feed_dict=fd)
 
     elif isinstance(weights[0], PondPrivateTensor):
       for i, w in enumerate(self.weights):

--- a/tf_encrypted/keras/engine/base_layer.py
+++ b/tf_encrypted/keras/engine/base_layer.py
@@ -9,9 +9,8 @@ import tf_encrypted as tfe
 from tf_encrypted import get_protocol
 from tf_encrypted.keras import backend as KE
 from tf_encrypted.keras.engine.base_layer_utils import unique_object_name
-from tf_encrypted.protocol.pond import (PondPrivateTensor,
-                                        PondMaskedTensor,
-                                       )
+from tf_encrypted.protocol.pond import PondPrivateTensor
+from tf_encrypted.protocol.pond import PondMaskedTensor
 
 logger = logging.getLogger('tf_encrypted')
 

--- a/tf_encrypted/keras/engine/base_layer.py
+++ b/tf_encrypted/keras/engine/base_layer.py
@@ -11,7 +11,6 @@ from tf_encrypted.keras import backend as KE
 from tf_encrypted.keras.engine.base_layer_utils import unique_object_name
 from tf_encrypted.protocol.pond import (PondPrivateTensor,
                                         PondMaskedTensor,
-                                        PondPublicTensor
                                        )
 
 logger = logging.getLogger('tf_encrypted')
@@ -134,17 +133,10 @@ class Layer(ABC):
 
     if isinstance(weights[0], np.ndarray):
       for i, w in enumerate(self.weights):
-        if isinstance(w, PondPrivateTensor):
-          shape = w.shape.as_list()
-          tfe_weights_pl = tfe.define_private_placeholder(shape)
-          fd = tfe_weights_pl.feed(weights[i].reshape(shape))
-          sess.run(tfe.assign(w, tfe_weights_pl), feed_dict=fd)
-        elif isinstance(w, PondPublicTensor):
-          shape = w.shape.as_list()
-          tfe_weights_pl = tfe.define_public_placeholder(shape)
-          fd = tfe_weights_pl.feed(weights[i].reshape(shape))
-          sess.run(tfe.assign(w, tfe_weights_pl), feed_dict=fd)
-
+        shape = w.shape.as_list()
+        tfe_weights_pl = tfe.define_private_placeholder(shape)
+        fd = tfe_weights_pl.feed(weights[i].reshape(shape))
+        sess.run(tfe.assign(w, tfe_weights_pl), feed_dict=fd)
     elif isinstance(weights[0], PondPrivateTensor):
       for i, w in enumerate(self.weights):
         shape = w.shape.as_list()

--- a/tf_encrypted/keras/layers/normalization.py
+++ b/tf_encrypted/keras/layers/normalization.py
@@ -184,6 +184,7 @@ class BatchNormalization(Layer):
             self.prot.add(moving_variance, self.epsilon)
         )
     )
+
     self.denom = denomtemp
 
     self.built = True

--- a/tf_encrypted/keras/layers/normalization.py
+++ b/tf_encrypted/keras/layers/normalization.py
@@ -138,6 +138,10 @@ class BatchNormalization(Layer):
                        "adjustment",
                        "BatchNormalization")
 
+    # Axis from get_config can be in ListWrapper format
+    if isinstance(axis, list):
+      axis = axis[0]
+
     # Axis -3 is equivalent to 1, and axis -1 is equivalent to 3, because the
     # input rank is required to be 4 (which is checked later).
     if axis not in (1, 3):
@@ -161,22 +165,26 @@ class BatchNormalization(Layer):
 
     if self.scale:
       gamma = self.gamma_initializer(param_shape)
-      self.gamma = self.prot.define_public_variable(gamma)
+      self.gamma = self.add_weight(gamma, make_private=False)
     else:
       self.gamma = None
 
     if self.center:
       beta = self.beta_initializer(param_shape)
-      self.beta = self.prot.define_public_variable(beta)
+      self.beta = self.add_weight(beta, make_private=False)
     else:
       self.beta = None
 
     moving_mean = self.moving_mean_initializer(param_shape)
-    self.moving_mean = self.prot.define_public_variable(moving_mean)
+    self.moving_mean = self.add_weight(moving_mean, make_private=False)
 
     moving_variance = self.moving_variance_initializer(param_shape)
+    moving_variance = self.add_weight(moving_variance, make_private=False)
 
-    denomtemp = 1.0 / tf.sqrt(moving_variance + self.epsilon)
+    # to_navive() tranformation is bad and not yet working
+    # Find solution to compute tf.sqrt on PondPublicVariable
+    # or use different approach
+    denomtemp = 1.0 / tf.sqrt(moving_variance.to_native(), + self.epsilon)
     self.denom = self.prot.define_public_variable(denomtemp)
 
     self.built = True

--- a/tf_encrypted/keras/layers/normalization.py
+++ b/tf_encrypted/keras/layers/normalization.py
@@ -184,8 +184,8 @@ class BatchNormalization(Layer):
     # to_navive() tranformation is bad and not yet working
     # Find solution to compute tf.sqrt on PondPublicVariable
     # or use different approach
-    denomtemp = 1.0 / tf.sqrt(moving_variance.to_native(), + self.epsilon)
-    self.denom = self.prot.define_public_variable(denomtemp)
+    denomtemp = 1.0 / tf.sqrt(moving_variance.to_native() + self.epsilon)
+    self.denom = self.prot.define_public_input("inputter", lambda: denomtemp)
 
     self.built = True
 

--- a/tf_encrypted/keras/layers/normalization.py
+++ b/tf_encrypted/keras/layers/normalization.py
@@ -225,7 +225,7 @@ class BatchNormalization(Layer):
         shape = w.shape.as_list()
         sess.run(self.prot.assign(w, weights[i].reshape(shape)))
 
-    
+
     denomtemp = self.prot.reciprocal(
         self.prot.sqrt(
             self.prot.add(self.moving_variance, self.epsilon)

--- a/tf_encrypted/keras/layers/normalization.py
+++ b/tf_encrypted/keras/layers/normalization.py
@@ -5,6 +5,7 @@ from tensorflow.python.keras import initializers
 
 from tf_encrypted.keras.engine import Layer
 from tf_encrypted.keras.layers.layers_utils import default_args_check
+from tf_encrypted.keras import backend as KE
 
 class BatchNormalization(Layer):
   """Batch normalization layer (Ioffe and Szegedy, 2014).
@@ -185,7 +186,9 @@ class BatchNormalization(Layer):
     # Find solution to compute tf.sqrt on PondPublicVariable
     # or use different approach
     denomtemp = 1.0 / tf.sqrt(moving_variance.to_native() + self.epsilon)
-    self.denom = self.prot.define_public_input("inputter", lambda: denomtemp)
+    self.denom = self.prot.define_public_variable(denomtemp)
+    sess = KE.get_session()
+    sess.run(self.denom.initializer)
 
     self.built = True
 

--- a/tf_encrypted/keras/layers/normalization.py
+++ b/tf_encrypted/keras/layers/normalization.py
@@ -1,11 +1,8 @@
 """Normalization layers implementation."""
-
-import tensorflow as tf
 from tensorflow.python.keras import initializers
 
 from tf_encrypted.keras.engine import Layer
 from tf_encrypted.keras.layers.layers_utils import default_args_check
-from tf_encrypted.keras import backend as KE
 
 class BatchNormalization(Layer):
   """Batch normalization layer (Ioffe and Szegedy, 2014).
@@ -185,10 +182,12 @@ class BatchNormalization(Layer):
     # to_navive() tranformation is bad and not yet working
     # Find solution to compute tf.sqrt on PondPublicVariable
     # or use different approach
-    denomtemp = 1.0 / tf.sqrt(moving_variance.to_native() + self.epsilon)
-    self.denom = self.prot.define_public_variable(denomtemp)
-    sess = KE.get_session()
-    sess.run(self.denom.initializer)
+    denomtemp = self.prot.reciprocal(
+        self.prot.sqrt(
+            self.prot.add(moving_variance, self.epsilon)
+        )
+    )
+    self.denom = denomtemp
 
     self.built = True
 

--- a/tf_encrypted/keras/layers/normalization.py
+++ b/tf_encrypted/keras/layers/normalization.py
@@ -179,9 +179,6 @@ class BatchNormalization(Layer):
     moving_variance = self.moving_variance_initializer(param_shape)
     moving_variance = self.add_weight(moving_variance, make_private=False)
 
-    # to_navive() tranformation is bad and not yet working
-    # Find solution to compute tf.sqrt on PondPublicVariable
-    # or use different approach
     denomtemp = self.prot.reciprocal(
         self.prot.sqrt(
             self.prot.add(moving_variance, self.epsilon)

--- a/tf_encrypted/keras/models/sequential_test.py
+++ b/tf_encrypted/keras/models/sequential_test.py
@@ -134,9 +134,12 @@ class TestSequential(unittest.TestCase):
       model.add(tf.keras.layers.Conv2D(2,
                                        (3, 3),
                                        batch_input_shape=input_shape))
-      model.add(tf.keras.layers.AveragePooling2D((2, 2)))
+      model.add(tf.keras.layers.ReLU())
       model.add(tf.keras.layers.BatchNormalization())
+      model.add(tf.keras.layers.AveragePooling2D((2, 2)))
       model.add(tf.keras.layers.Conv2D(2, (3, 3)))
+      model.add(tf.keras.layers.ReLU())
+      model.add(tf.keras.layers.BatchNormalization())
       model.add(tf.keras.layers.AveragePooling2D((2, 2)))
       model.add(tf.keras.layers.Flatten())
       model.add(tf.keras.layers.Dense(num_classes, name="logit"))
@@ -158,39 +161,6 @@ class TestSequential(unittest.TestCase):
     with KE.get_session() as sess:
       actual = sess.run(y.reveal())
 
-      np.testing.assert_allclose(actual, expected, rtol=1e-2, atol=1e-2)
-
-    KE.clear_session()
-
-  def test_clone_batchnorm(self):
-
-    input_shape = (1, 5, 5, 1)
-    input_data = np.random.normal(size=input_shape)
-
-    with tf.Session():
-      model = tf.keras.models.Sequential()
-
-      model.add(tf.keras.layers.BatchNormalization(
-          batch_input_shape=input_shape))
-
-      expected = model.predict(input_data)
-      k_weights = model.get_weights()
-      k_config = model.get_config()
-
-    with tfe.protocol.SecureNN():
-      x = tfe.define_private_input(
-          "inputter",
-          lambda: tf.convert_to_tensor(input_data))
-
-      tfe_model = tfe.keras.models.model_from_config(k_config)
-
-      tfe_model.set_weights(k_weights)
-      y = tfe_model(x)
-
-    with KE.get_session() as sess:
-      actual = sess.run(y.reveal())
-      for w in tfe_model.layers[0].weights:
-        print(sess.run(w.to_native()))
       np.testing.assert_allclose(actual, expected, rtol=1e-2, atol=1e-2)
 
     KE.clear_session()

--- a/tf_encrypted/keras/models/sequential_test.py
+++ b/tf_encrypted/keras/models/sequential_test.py
@@ -135,6 +135,7 @@ class TestSequential(unittest.TestCase):
                                        (3, 3),
                                        batch_input_shape=input_shape))
       model.add(tf.keras.layers.AveragePooling2D((2, 2)))
+      model.add(tf.keras.layers.BatchNormalization())
       model.add(tf.keras.layers.Conv2D(2, (3, 3)))
       model.add(tf.keras.layers.AveragePooling2D((2, 2)))
       model.add(tf.keras.layers.Flatten())
@@ -150,6 +151,7 @@ class TestSequential(unittest.TestCase):
           lambda: tf.convert_to_tensor(input_data))
 
       tfe_model = tfe.keras.models.model_from_config(k_config)
+
       tfe_model.set_weights(k_weights)
       y = tfe_model(x)
 

--- a/tf_encrypted/protocol/ops_test.py
+++ b/tf_encrypted/protocol/ops_test.py
@@ -492,6 +492,41 @@ class TestNegative(unittest.TestCase):
 
     assert np.isclose(out_pond, out_tensorflow, atol=0.6).all()
 
+class TestSqrt(unittest.TestCase):
+  def setUp(self):
+    tf.reset_default_graph()
+
+  def test_sqrt(self):
+    input_shape = [2, 2]
+    input_sqrt = np.ones(input_shape)
+
+    # reshape pond
+    with tfe.protocol.Pond() as prot:
+
+      sqrt_input = prot.define_public_variable(input_sqrt)
+
+      sqrt_out_pond = prot.sqrt(sqrt_input)
+
+      with tfe.Session() as sess:
+
+        sess.run(tf.global_variables_initializer())
+        # outputs
+        out_pond = sess.run(sqrt_out_pond)
+
+      # reset graph
+      tf.reset_default_graph()
+
+      with tf.Session() as sess:
+        x = tf.Variable(input_sqrt, dtype=tf.float32)
+
+        sqrt_out_tf = tf.math.sqrt(x)
+
+        sess.run(tf.global_variables_initializer())
+
+        out_tensorflow = sess.run(sqrt_out_tf)
+
+    assert np.isclose(out_pond, out_tensorflow, atol=0.6).all()
+
 
 class TestPad(unittest.TestCase):
   def setUp(self):

--- a/tf_encrypted/protocol/pond/pond.py
+++ b/tf_encrypted/protocol/pond/pond.py
@@ -2071,10 +2071,13 @@ class PondPublicPlaceholder(PondPublicTensor):
     """
     Feed `value` to placeholder
     """
+
     assert isinstance(value, np.ndarray), type(value)
 
-    feed0 = self.placeholder_on_0.feed(value)
-    feed1 = self.placeholder_on_1.feed(value)
+    enc = self.prot._encode(value, self.is_scaled)  # pylint: disable=protected-access
+
+    feed0 = self.placeholder_on_0.feed(enc)
+    feed1 = self.placeholder_on_1.feed(enc)
     return {**feed0, **feed1}
 
 

--- a/tf_encrypted/protocol/pond/pond.py
+++ b/tf_encrypted/protocol/pond/pond.py
@@ -4133,12 +4133,12 @@ def _sqrt_public(prot, x):
   backing_dtype = x.backing_dtype
   x_on_0, x_on_1 = x.unwrapped
   is_scaled = x.is_scaled
-  assert is_scaled, "Can only reciprocal of scaled numbers"
+  assert is_scaled, "Can only sqrt of scaled numbers"
 
-  with tf.name_scope("reciprocal"):
+  with tf.name_scope("sqrt"):
 
     with tf.device(prot.server_0.device_name):
-      # decode value as ordinary tensor locally and compute reciprocal
+      # decode value as ordinary tensor locally and compute sqrt
       x_on_0_decoded = prot._decode(x_on_0, is_scaled)  # pylint: disable=protected-access
       y_on_0_decoded = tf.math.sqrt(x_on_0_decoded)
       # re-encode and re-wrap
@@ -4149,7 +4149,7 @@ def _sqrt_public(prot, x):
               tf_int_type=backing_dtype.native_type))
 
     with tf.device(prot.server_1.device_name):
-      # decode value as ordinary tensor locally and compute reciprocal
+      # decode value as ordinary tensor locally and compute sqrt
       x_on_1_decoded = prot._decode(x_on_1, is_scaled)  # pylint: disable=protected-access
       y_on_1_decoded = tf.math.sqrt(x_on_1_decoded)
       # re-encode and re-wrap

--- a/tf_encrypted/protocol/pond/pond.py
+++ b/tf_encrypted/protocol/pond/pond.py
@@ -837,11 +837,6 @@ class Pond(Protocol):
 
       with tf.name_scope("assign"):
 
-        # Having this control_dependencies is important in order to avoid that
-        # computationally-dependent shares are updated in different pace
-        # (e.g., share0 is computed from share1, and we need to make sure that
-        # share1 is NOT already updated).
-        # See https://github.com/tf-encrypted/tf-encrypted/pull/665 for details.
         with tf.control_dependencies(val0.support + val1.support):
 
           with tf.device(self.server_0.device_name):

--- a/tf_encrypted/protocol/pond/pond_test.py
+++ b/tf_encrypted/protocol/pond/pond_test.py
@@ -221,6 +221,30 @@ class TestPondAssign(unittest.TestCase):
       result = sess.run(a.reveal())
       assert result == np.array([101.])
 
+  def test_public_assign(self):
+
+    tf.reset_default_graph()
+
+    with tfe.protocol.Pond() as prot:
+      x_var = prot.define_public_variable(np.ones(shape=(2, 2)))
+      data = np.zeros((2, 2))
+      x_pl = tfe.define_public_placeholder(shape=(2, 2))
+      fd = x_pl.feed(data.reshape((2, 2)))
+
+    with tfe.Session() as sess:
+      sess.run(tf.global_variables_initializer())
+      sess.run(tfe.assign(x_var, x_pl), feed_dict=fd)
+
+      result = sess.run(x_var)
+      np.testing.assert_array_equal(result, np.zeros([2, 2]))
+
+
+
+
+
+
+
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/tf_encrypted/protocol/pond/pond_test.py
+++ b/tf_encrypted/protocol/pond/pond_test.py
@@ -239,12 +239,5 @@ class TestPondAssign(unittest.TestCase):
       np.testing.assert_array_equal(result, np.zeros([2, 2]))
 
 
-
-
-
-
-
-
-
 if __name__ == '__main__':
   unittest.main()

--- a/tf_encrypted/protocol/pond/pond_test.py
+++ b/tf_encrypted/protocol/pond/pond_test.py
@@ -226,17 +226,15 @@ class TestPondAssign(unittest.TestCase):
     tf.reset_default_graph()
 
     with tfe.protocol.Pond() as prot:
-      x_var = prot.define_public_variable(np.ones(shape=(2, 2)))
-      data = np.zeros((2, 2))
+      x_var = prot.define_public_variable(np.zeros(shape=(2, 2)))
+      data = np.ones((2, 2))
       x_pl = tfe.define_public_placeholder(shape=(2, 2))
       fd = x_pl.feed(data.reshape((2, 2)))
 
     with tfe.Session() as sess:
-      sess.run(tf.global_variables_initializer())
       sess.run(tfe.assign(x_var, x_pl), feed_dict=fd)
-
       result = sess.run(x_var)
-      np.testing.assert_array_equal(result, np.zeros([2, 2]))
+      np.testing.assert_array_equal(result, np.ones([2, 2]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hey @mortendahl,

It's a WIP PR. This bug #705 is a bit more complicated than I expected. 

When we clone the a model, first we instantiate the model. During this process, the weights (TFE variables) from each layer gets stored in a `self.weights` model attribute. Then with `set_weights` we assign the numpy weights to the TFE variables.

The difference with Batchnorm is that the weights are not private variables but public variables (e.g moving_variance) because it involves sqrt, division etc. 

The problem is that we are less equipped to assign numpy weights (define_public_placeholder) to `PublicPondVariable`.