### PR TITLE
Bugfix: FL example broadcast leak

### DIFF
--- a/examples/federated-learning/players.py
+++ b/examples/federated-learning/players.py
@@ -80,11 +80,12 @@ class BaseModelOwner:
       self._update_one_round(data_owners, **kwargs)
 
       # Broadcast master model
+      # TODO: don't assume it's a tf.keras model
+      master_vars = self.model.trainable_variables
       for owner in data_owners:
-        # TODO: don't assume it's a tf.keras model
-        for var_do, var_mo in zip(owner.model.trainable_variables,
-                                  self.model.trainable_variables):
-          var_do.assign(var_mo)
+        with owner.device:
+          for v_d, v_m in zip(owner.model.trainable_variables, master_vars):
+            v_d.assign(v_m)
 
       # Evaluate once (maybe)
       if evaluate and (r + 1) % evaluate_every == 0:

--- a/examples/federated-learning/players.py
+++ b/examples/federated-learning/players.py
@@ -82,7 +82,9 @@ class BaseModelOwner:
       # Broadcast master model
       for owner in data_owners:
         # TODO: don't assume it's a tf.keras model
-        owner.model.set_weights(self.model.get_weights())
+        for var_do, var_mo in zip(owner.model.trainable_variables,
+                                  self.model.trainable_variables):
+          var_do.assign(var_mo)
 
       # Evaluate once (maybe)
       if evaluate and (r + 1) % evaluate_every == 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pylint==2.3.1
 jmespath==0.9.3
 numpy==1.17.2
 protobuf==3.6.1
-pyasn1==0.4.2
+pyasn1==0.4.8
 s3transfer==0.1.13
 tensorflow==2.0.0
 termcolor==1.1.0


### PR DESCRIPTION
In the federated-learning example, there was a bug where data was leaking out of the TF graph during the broadcast step due to calls to Keras's `get_weights`/`set_weights`. This uses variable assignment to update the state on each data owner, pinning to each data_owner's device.

Warning: I wasn't able to get tensorboard graph viz working in TF 2.0, so I haven't been able to verify: (1) that this is the only leak, and (2) that this fixes the leak.