### PR TITLE
Add link to the csv reading example to LR page and first page

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Examples and uses:
 
 - [Experimenting with TF Encrypted](https://medium.com/dropoutlabs/experimenting-with-tf-encrypted-fe37977ff03c) walks through a simple example of turning an existing TensorFlow prediction model private (*by Morten Dahl and Jason Mancuso at Dropout Labs*)
 
+- [Introducing TF Encrypted](https://alibaba-gemini-lab.github.io/docs/blog/tfe/) walks through a simple example showing two data owners jointly training a logistic regression model using TF Encrypted on a vertically split dataset. (*by Alibaba Gemini Lab*)
+
 Presentations:
 
 - [Privacy-Preserving Machine Learning with TensorFlow](https://github.com/dropoutlabs/tf-world-tutorial), TF World 2019 (*by Jason Mancuso and Yann Dupis at Dropout Labs*)

--- a/examples/logistic/README.md
+++ b/examples/logistic/README.md
@@ -6,3 +6,5 @@ The examples are as follows:
 - [`prediction_joint.py`](./prediction_joint.py) shows how several clients can combine features for a prediction
 - [`training_single.py`](./training_single.py) shows how a model can be privately trained on data from a single owner
 - [`training_joint.py`](./training_joint.py) shows how several data owners can jointly train on their combined data
+
+Note that the training data in the above examples are randomly sampled. [Here](https://alibaba-gemini-lab.github.io/docs/blog/tfe/) gives a more realistic example showing two data owners jointly training on vertically split dataset, which are separately read from their local csv files.


### PR DESCRIPTION
The example contains several miscellaneous files such as config.json and dataset and training codes for different parties,  so I guess it's better in a separate link rather than PR the full example.