### PR TITLE
Configuration for coding style

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,8 @@ $(BUILD_CONVERTER_README): $(BUILD_RESERVED_SCOPES) pythoncheck
 lint: $(BUILD_CONVERTER_README) pythoncheck
 	pylint tf_encrypted examples operations
 	pylint bin/run bin/process bin/pull_model bin/serve bin/write
+	flake8 tf_encrypted
+	yapf --recursive --parallel --diff tf_encrypted > /dev/null 
 
 typecheck: pythoncheck
 	MYPYPATH=$(CURRENT_DIR):$(CURRENT_DIR)/stubs mypy tf_encrypted

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,10 @@ lint: $(BUILD_CONVERTER_README) pythoncheck
 	pylint tf_encrypted examples operations
 	pylint bin/run bin/process bin/pull_model bin/serve bin/write
 	flake8 tf_encrypted
-	yapf --recursive --parallel --diff tf_encrypted > /dev/null 
+	yapf --diff --recursive --parallel tf_encrypted
+
+format: pythoncheck
+	yapf --in-place --recursive --parallel tf_encrypted
 
 typecheck: pythoncheck
 	MYPYPATH=$(CURRENT_DIR):$(CURRENT_DIR)/stubs mypy tf_encrypted

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,7 @@ pytest-xdist==1.26.1
 nose==1.3.7
 pyyaml==5.1
 sphinx==2.1.2
+flake8==3.6.0
+flake8-docstrings==1.5.0
+flake8-mypy==17.8.0
+yapf==0.29.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,19 @@
+[yapf]
+based_on_style = google
+indent_width = 2
+column_limit = 90
+split_before_dict_set_generator = True
+coalesce_brackets = True
+# split_before_first_argument = True
+
+[flake8]
+max-line-length = 90
+select = T,D,W,E,F
+ignore = E111,E114,E126,T484,T499,D202
+
+[pylint]
+max-default-line-length = 90
+
+[pydocstyle]
+
+[mypy]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,18 +1,18 @@
 [yapf]
 based_on_style = google
 indent_width = 2
-column_limit = 90
+column_limit = 80
 split_before_dict_set_generator = True
 coalesce_brackets = True
 # split_before_first_argument = True
 
 [flake8]
-max-line-length = 90
+max-line-length = 80
 select = T,D,W,E,F
 ignore = E111,E114,E126,T484,T499,D202
 
 [pylint]
-max-default-line-length = 90
+max-default-line-length = 80
 
 [pydocstyle]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,18 +1,15 @@
 [yapf]
-based_on_style = google
-indent_width = 2
-column_limit = 80
-split_before_dict_set_generator = True
-coalesce_brackets = True
-# split_before_first_argument = True
+based_on_style=google
+indent_width=2
+column_limit=80
+split_before_dict_set_generator=True
+coalesce_brackets=True
+# split_before_first_argument=True
 
 [flake8]
-max-line-length = 80
-select = T,D,W,E,F
-ignore = E111,E114,E126,T484,T499,D202
-
-[pylint]
-max-default-line-length = 80
+max-line-length=80
+select=T,D,W,E,F
+ignore=E111,E114,E126,T484,T499,D202
 
 [pydocstyle]
 


### PR DESCRIPTION
Closes #738.

Missing:
- [ ] compare and potentially update linting rules against match current code base
- [ ] update development docs to reflect use of tools (not least `yapf`)
- [x] update makefile and CI to use configuration