### PR TITLE
Aby3 Improvement

### DIFF
--- a/tf_encrypted/protocol/aby3/aby3.py
+++ b/tf_encrypted/protocol/aby3/aby3.py
@@ -1147,16 +1147,6 @@ class ABY3(Protocol):
       raise TypeError("Only support iterating ABY3PrivateTensor.")
     return self.dispatch("iterate", tensor, batch_size, repeat, shuffle, seed)
 
-  def blinded_shuffle(self, tensor: "ABY3PrivateTensor"):
-    """
-    Shuffle the rows of the given tenosr privately.
-    After the shuffle, none of the share holder could know the exact shuffle order.
-    """
-    if not isinstance(tensor, ABY3PrivateTensor):
-      raise TypeError(("Only support blindly shuffle ABY3PrivateTensor. "
-                       "For public tensor, use the shuffle() method"))
-    return self.dispatch("blinded_shuffle", tensor)
-
   def dispatch(self, base_name, *args, container=None, **kwargs):
     """
     Finds the correct protocol logicto perform based on the dispatch_id

--- a/tf_encrypted/protocol/aby3/aby3_test.py
+++ b/tf_encrypted/protocol/aby3/aby3_test.py
@@ -522,17 +522,13 @@ class TestABY3(unittest.TestCase):
                                     share_type=BOOLEAN)
 
     # Parallel prefix adder. It is simply an adder for boolean sharing.
-    z1 = tfe.B_ppa(x, y, topology="sklansky")
-    z2 = tfe.B_ppa(x, y, topology="kogge_stone")
+    z = tfe.B_ppa(x, y)
 
     with tfe.Session() as sess:
       # initialize variables
       sess.run(tfe.global_variables_initializer())
       # reveal result
-      result = sess.run(z1.reveal())
-      np.testing.assert_allclose(result, np.array([[8, 10, 12], [14, 16, 18]]), rtol=0.0, atol=0.01)
-
-      result = sess.run(z2.reveal())
+      result = sess.run(z.reveal())
       np.testing.assert_allclose(result, np.array([[8, 10, 12], [14, 16, 18]]), rtol=0.0, atol=0.01)
       print("test_ppa_private_private succeeds")
 
@@ -1000,6 +996,29 @@ class TestABY3(unittest.TestCase):
       print(sess.run(y.reveal()))
       print(sess.run(x.reveal()))
       print(sess.run(z.reveal()))
+
+
+  def test_while_loop(self):
+
+    def cond(i, a):
+      return i < 10
+    def body(i, a):
+      return (i + 1, a + 10)
+
+    i = 0
+    x = tfe.define_private_variable(tf.constant([[1, 2, 3], [4, 5, 6]]))
+    y = x * 1
+    r1, r2 = tfe.while_loop(cond, body, [i, y])
+
+    with tfe.Session() as sess:
+      # initialize variables
+      sess.run(tfe.global_variables_initializer())
+      # reveal result
+      result = sess.run(r1)
+      np.testing.assert_allclose(result, np.array(10), rtol=0.0, atol=0.01)
+      result = sess.run(r2.reveal())
+      np.testing.assert_allclose(result, np.array([[101, 102, 103], [104, 105, 106]]), rtol=0.0, atol=0.01)
+      print("test_while_loop succeeds")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Some important improvements to the ABY3 implementation:

1. Implement TFE's private while loop, so that for some algorithms, we can use `tfe.while_loop`, instead of Python's native for loop that creates unnecessary redundant graph nodes.
2. Update parallel prefix adder (`_B_ppa_private_private`)  to use `tfe.while_loop`. In my evaluation, this is at least twice faster than the previous version that uses Python's for loop.
3. Add indexer for ABY3PublicTensor for accessing the sub tensor of a ABY3PublicTensor
4. Some minor cleaning and renaming