### PR TITLE
Remove crypto_producer from Pond

### DIFF
--- a/tf_encrypted/protocol/pond/pond_test.py
+++ b/tf_encrypted/protocol/pond/pond_test.py
@@ -5,9 +5,10 @@ import numpy as np
 import tensorflow as tf
 
 import tf_encrypted as tfe
-from tf_encrypted.protocol.pond import PondPublicTensor
+from tf_encrypted.protocol.pond import PondPublicTensor, PondMaskedTensor
 from tf_encrypted.tensor import int64factory, int100factory, native_factory
 from tf_encrypted.tensor import fixed100, fixed100_ni
+from .pond import _gather_masked, _indexer_masked, _negative_masked
 
 
 class TestPond(unittest.TestCase):
@@ -156,6 +157,54 @@ class TestShare(unittest.TestCase):
   def test_prime(self):
     self._core_test_sharing(native_factory(tf.int32, 67))
 
+class TestMasked(unittest.TestCase):
+
+  def _setup(self, dtype):
+    prot = tfe.protocol.Pond()
+    plain_tensor = dtype.tensor(np.array([[1, 2, 3], [4, 5, 6]]))
+    unmasked = prot._share_and_wrap(plain_tensor, False)  # pylint: disable=protected-access
+    a0 = dtype.sample_uniform(plain_tensor.shape)
+    a1 = dtype.sample_uniform(plain_tensor.shape)
+    a = a0 + a1
+    alpha = plain_tensor - a
+    x = PondMaskedTensor(self, unmasked, a, a0, a1, alpha, alpha, False)
+    return prot, x
+
+  def test_indexer(self):
+
+    with tf.Graph().as_default():
+
+      prot, x = self._setup(int64factory)
+      indexed = _indexer_masked(prot, x, 0)
+
+      with tfe.Session() as sess:
+        actual = sess.run(indexed.reveal().to_native())
+        expected = np.array([1, 2, 3])
+        np.testing.assert_array_equal(actual, expected)
+
+  def test_gather(self):
+
+    with tf.Graph().as_default():
+
+      prot, x = self._setup(int64factory)
+      gathered = _gather_masked(prot, x, [0, 2], axis=1)
+
+      with tfe.Session() as sess:
+        actual = sess.run(gathered.reveal().to_native())
+        expected = np.array([[1, 3], [4, 6]])
+        np.testing.assert_array_equal(actual, expected)
+
+  def test_negative_masked(self):
+
+    with tf.Graph().as_default():
+
+      prot, x = self._setup(int64factory)
+      negative = _negative_masked(prot, x)
+
+      with tfe.Session() as sess:
+        actual = sess.run(negative.reveal().to_native())
+        expected = np.array([[-1, -2, -3], [-4, -5, -6]])
+        np.testing.assert_array_equal(actual, expected)
 
 class TestIdentity(unittest.TestCase):
 

--- a/tf_encrypted/protocol/pond/triple_sources.py
+++ b/tf_encrypted/protocol/pond/triple_sources.py
@@ -104,6 +104,22 @@ class BaseTripleSource(TripleSource):
 
     return a_t
 
+  def gather_mask(self, a, indices, axis):
+
+    with tf.name_scope("mask-transformation"):
+      with tf.device(self.producer.device_name):
+        a_g = a.gather(indices, axis=axis)
+
+    return a_g
+
+  def negative_mask(self, a):
+
+    with tf.name_scope("mask-transformation"):
+      with tf.device(self.producer.device_name):
+        a_negative = a.negative()
+
+    return a_negative
+
   def strided_slice_mask(self, a, args, kwargs):
 
     with tf.name_scope("mask-transformation"):

--- a/tf_encrypted/protocol/securenn/securenn.py
+++ b/tf_encrypted/protocol/securenn/securenn.py
@@ -55,7 +55,7 @@ class SecureNN(Pond):
     super(SecureNN, self).__init__(
         server_0=server_0,
         server_1=server_1,
-        crypto_producer=server_2,
+        triple_source=server_2,
         tensor_factory=tensor_factory,
         **kwargs
     )


### PR DESCRIPTION
Addresses https://github.com/tf-encrypted/tf-encrypted/issues/751

Removed `crypto_producer` and made `triple_source` accept values of multiple types instead of forcing all users of Pond to instantiate a `TripleSource`. Also, move the logic of gather_mask and negative_mask to `BaseTripleSource`. This way, Pond defers to triple_source for computing the operation using triple_source`s internal crypto producer.

btw, the test for `_indexer_masked` was not needed for this change. I was using it to make sure my tests actually work before writing tests for `_gather_masked` and `_negative_masked`. I kept it in since more tests are generally good ;)

Also, I wanted to use pytest `setUp` instead of my own `_setup` but I was not familiar with how tf handles graph contexts and if I can set it up once and use it later...