### PR TITLE
add back the undefined variable

### DIFF
--- a/tf_encrypted/protocol/pond/pond.py
+++ b/tf_encrypted/protocol/pond/pond.py
@@ -3684,7 +3684,7 @@ def _transpose_private(prot, x, perm=None):
 def _transpose_masked(prot, x, perm=None):
   assert isinstance(x, PondMaskedTensor)
 
-  _, a0, a1, alpha_on_0, alpha_on_1 = x.unwrapped
+  a, a0, a1, alpha_on_0, alpha_on_1 = x.unwrapped
 
   with tf.name_scope("transpose"):
 


### PR DESCRIPTION
Variable `a` was dropped as part of a merge conflict resolution. This PR adds it back.

Will merge after https://github.com/tf-encrypted/tf-encrypted/issues/751 is merged.