### PR TITLE
Add additional dtypes to sodium primitives

### DIFF
--- a/primitives/tf_encrypted/primitives/sodium/cc/easy_box_kernels.cc
+++ b/primitives/tf_encrypted/primitives/sodium/cc/easy_box_kernels.cc
@@ -198,11 +198,47 @@ public:
 
 REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxGenKeypair").Device(DEVICE_CPU), SodiumEasyBoxGenKeypair);
 REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxGenNonce").Device(DEVICE_CPU), SodiumEasyBoxGenNonce);
+REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxSealDetached").Device(DEVICE_CPU).TypeConstraint<bfloat16>("plaintext_dtype"), 
+    SodiumEasyBoxSealDetached<bfloat16>);
 REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxSealDetached").Device(DEVICE_CPU).TypeConstraint<float>("plaintext_dtype"), 
     SodiumEasyBoxSealDetached<float>);
+REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxSealDetached").Device(DEVICE_CPU).TypeConstraint<double>("plaintext_dtype"), 
+    SodiumEasyBoxSealDetached<double>);
+REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxSealDetached").Device(DEVICE_CPU).TypeConstraint<int8>("plaintext_dtype"), 
+    SodiumEasyBoxSealDetached<int8>);
+REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxSealDetached").Device(DEVICE_CPU).TypeConstraint<int16>("plaintext_dtype"), 
+    SodiumEasyBoxSealDetached<int16>);
+REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxSealDetached").Device(DEVICE_CPU).TypeConstraint<int32>("plaintext_dtype"), 
+    SodiumEasyBoxSealDetached<int32>);
+REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxSealDetached").Device(DEVICE_CPU).TypeConstraint<int64>("plaintext_dtype"), 
+    SodiumEasyBoxSealDetached<int64>);
 REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxSealDetached").Device(DEVICE_CPU).TypeConstraint<uint8>("plaintext_dtype"), 
     SodiumEasyBoxSealDetached<uint8>);
+REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxSealDetached").Device(DEVICE_CPU).TypeConstraint<uint16>("plaintext_dtype"), 
+    SodiumEasyBoxSealDetached<uint16>);
+REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxSealDetached").Device(DEVICE_CPU).TypeConstraint<uint32>("plaintext_dtype"), 
+    SodiumEasyBoxSealDetached<uint32>);
+REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxSealDetached").Device(DEVICE_CPU).TypeConstraint<uint64>("plaintext_dtype"), 
+    SodiumEasyBoxSealDetached<uint64>);
+REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxOpenDetached").Device(DEVICE_CPU).TypeConstraint<bfloat16>("plaintext_dtype"), 
+    SodiumEasyBoxOpenDetached<bfloat16>);
 REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxOpenDetached").Device(DEVICE_CPU).TypeConstraint<float>("plaintext_dtype"), 
     SodiumEasyBoxOpenDetached<float>);
+REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxOpenDetached").Device(DEVICE_CPU).TypeConstraint<double>("plaintext_dtype"), 
+    SodiumEasyBoxOpenDetached<double>);
+REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxOpenDetached").Device(DEVICE_CPU).TypeConstraint<int8>("plaintext_dtype"), 
+    SodiumEasyBoxOpenDetached<int8>);
+REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxOpenDetached").Device(DEVICE_CPU).TypeConstraint<int16>("plaintext_dtype"), 
+    SodiumEasyBoxOpenDetached<int16>);
+REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxOpenDetached").Device(DEVICE_CPU).TypeConstraint<int32>("plaintext_dtype"), 
+    SodiumEasyBoxOpenDetached<int32>);
+REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxOpenDetached").Device(DEVICE_CPU).TypeConstraint<int64>("plaintext_dtype"), 
+    SodiumEasyBoxOpenDetached<int64>);
 REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxOpenDetached").Device(DEVICE_CPU).TypeConstraint<uint8>("plaintext_dtype"), 
     SodiumEasyBoxOpenDetached<uint8>);
+REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxOpenDetached").Device(DEVICE_CPU).TypeConstraint<uint16>("plaintext_dtype"), 
+    SodiumEasyBoxOpenDetached<uint16>);
+REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxOpenDetached").Device(DEVICE_CPU).TypeConstraint<uint32>("plaintext_dtype"), 
+    SodiumEasyBoxOpenDetached<uint32>);
+REGISTER_KERNEL_BUILDER(Name("SodiumEasyBoxOpenDetached").Device(DEVICE_CPU).TypeConstraint<uint64>("plaintext_dtype"), 
+    SodiumEasyBoxOpenDetached<uint64>);

--- a/primitives/tf_encrypted/primitives/sodium/cc/ops.cc
+++ b/primitives/tf_encrypted/primitives/sodium/cc/ops.cc
@@ -35,7 +35,7 @@ REGISTER_OP("SodiumEasyBoxGenNonce")
     });
 
 REGISTER_OP("SodiumEasyBoxSealDetached")
-    .Attr("plaintext_dtype: {uint8, float32}")
+    .Attr("plaintext_dtype: {uint8, uint16, uint32, uint64, int8, int16, int32, int64, bfloat16, float32, float64}")
     .Input("plaintext: plaintext_dtype")
     .Input("nonce: uint8")
     .Input("pk_receiver: uint8")
@@ -79,7 +79,7 @@ REGISTER_OP("SodiumEasyBoxSealDetached")
     });
 
 REGISTER_OP("SodiumEasyBoxOpenDetached")
-    .Attr("plaintext_dtype: {uint8, float32}")
+    .Attr("plaintext_dtype: {uint8, uint16, uint32, uint64, int8, int16, int32, int64, bfloat16, float32, float64}")
     .Input("ciphertext: uint8")
     .Input("mac: uint8")
     .Input("nonce: uint8")

--- a/primitives/tf_encrypted/primitives/sodium/python/easy_box_test.py
+++ b/primitives/tf_encrypted/primitives/sodium/python/easy_box_test.py
@@ -52,7 +52,19 @@ class TestEasyBox(parameterized.TestCase):
         {"eager": eager, "m": m, "dtype": dtype, "dtype_size": dtype_size}
         for eager in (True, False)
         for m in (5, [5], [[1, 2], [3, 4]])
-        for dtype, dtype_size in [(tf.uint8, 1), (tf.float32, 4)]
+        for dtype, dtype_size in [
+            (tf.uint8, 1),
+            (tf.uint16, 2),
+            (tf.uint32, 4),
+            (tf.uint64, 8),
+            (tf.int8, 1),
+            (tf.int16, 2),
+            (tf.int32, 4),
+            (tf.int64, 8),
+            (tf.bfloat16, 2),
+            (tf.float32, 4),
+            (tf.float64, 8),
+        ]
     )
     def test_seal_and_open(self, eager, m, dtype, dtype_size):
         with tf_execution_mode(eager):
@@ -82,7 +94,7 @@ class TestEasyBox(parameterized.TestCase):
         assert plaintext_recovered.dtype == plaintext.dtype
         assert plaintext_recovered.shape == plaintext.shape
         if eager:
-            np.testing.assert_equal(plaintext_recovered, np.array(m))
+            np.testing.assert_equal(plaintext_recovered.numpy(), np.array(m))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add {uint,int}{8,16,32,64}, float64, and bfloat16 to allowed tf dtypes for sodium primitives.

per https://github.com/tf-encrypted/tf-encrypted/pull/784#issuecomment-608305734