### PR TITLE
updates build_pip_package rule to include paillier_py

### DIFF
--- a/primitives/BUILD
+++ b/primitives/BUILD
@@ -4,6 +4,7 @@ sh_binary(
     name = "build_pip_package",
     srcs = ["build_pip_package.sh"],
     data = [
+        "//tf_encrypted/primitives/paillier:paillier_py",
         "//tf_encrypted/primitives/sodium:sodium_py",
         "//tf_encrypted/test:test_py",
     ] + glob([


### PR DESCRIPTION
before, pip package for `tf_encrypted.primitives` didn't include the paillier submodule