### PR TITLE
Force unset linker opt in libsodium configure_make rule

### DIFF
--- a/external/sodium/BUILD
+++ b/external/sodium/BUILD
@@ -12,4 +12,12 @@ configure_make(
     lib_source = "@sodium//:.",
     static_libraries = ["libsodium.a"],
     visibility = ["//visibility:public"],
+    # libsodium script uses its own linker, so explicitly unset the default
+    # libtool from rules_foreign_cc
+    # (otherwise, if the libtool from bazel's toolchain is supplied,
+    # the build script has problems with passing output file to libtool)
+    # see bazelbuild/rules_foreign_cc#315
+    configure_env_vars = {
+        "AR": "",
+    },
 )


### PR DESCRIPTION
Fixes an issue on OS X where the default libtool linker used by bazel's `rules_foreign_cc` was breaking something that libsodium expects to use during its build. This was exhibiting the same error described in https://github.com/bazelbuild/rules_foreign_cc/issues/185, and the fix is mentioned in https://github.com/bazelbuild/rules_foreign_cc/pull/315