### PR TITLE
support insecure randomness in ABY3 for research uses

### DIFF
--- a/tf_encrypted/protocol/aby3/aby3.py
+++ b/tf_encrypted/protocol/aby3/aby3.py
@@ -101,11 +101,17 @@ class ABY3(Protocol):
         else:
             # Shape and Type are kept consistent with the 'secure_seed' version
             with tf.device(self.servers[0].device_name):
-                seed_0 = tf.random.uniform([2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64)
+                seed_0 = tf.random.uniform(
+                    [2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64
+                )
             with tf.device(self.servers[1].device_name):
-                seed_1 = tf.random.uniform([2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64)
+                seed_1 = tf.random.uniform(
+                    [2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64
+                )
             with tf.device(self.servers[2].device_name):
-                seed_2 = tf.random.uniform([2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64)
+                seed_2 = tf.random.uniform(
+                    [2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64
+                )
 
         # Replicated keys
         # NOTE: The following `with` contexts do NOT have any impact for the Python-only operations.
@@ -149,11 +155,17 @@ class ABY3(Protocol):
         else:
             # Shape and Type are kept consistent with the 'secure_seed' version
             with tf.device(self.servers[0].device_name):
-                seed_0 = tf.random.uniform([2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64)
+                seed_0 = tf.random.uniform(
+                    [2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64
+                )
             with tf.device(self.servers[1].device_name):
-                seed_1 = tf.random.uniform([2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64)
+                seed_1 = tf.random.uniform(
+                    [2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64
+                )
             with tf.device(self.servers[2].device_name):
-                seed_2 = tf.random.uniform([2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64)
+                seed_2 = tf.random.uniform(
+                    [2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64
+                )
 
         with tf.device(self.servers[0].device_name):
             b2a_keys_1[0][0] = seed_0
@@ -180,11 +192,17 @@ class ABY3(Protocol):
         else:
             # Shape and Type are kept consistent with the 'secure_seed' version
             with tf.device(self.servers[0].device_name):
-                seed_0 = tf.random.uniform([2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64)
+                seed_0 = tf.random.uniform(
+                    [2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64
+                )
             with tf.device(self.servers[1].device_name):
-                seed_1 = tf.random.uniform([2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64)
+                seed_1 = tf.random.uniform(
+                    [2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64
+                )
             with tf.device(self.servers[2].device_name):
-                seed_2 = tf.random.uniform([2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64)
+                seed_2 = tf.random.uniform(
+                    [2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64
+                )
 
         with tf.device(self.servers[0].device_name):
             b2a_keys_2[0][0] = seed_0

--- a/tf_encrypted/protocol/aby3/aby3.py
+++ b/tf_encrypted/protocol/aby3/aby3.py
@@ -88,18 +88,24 @@ class ABY3(Protocol):
         """
     Initial setup for pairwise randomness: Every two parties hold a shared key.
     """
-        if not crypto.supports_seeded_randomness():
-            raise NotImplementedError(
-                "Secure randomness implementation is not available."
-            )
 
         keys = [[None, None], [None, None], [None, None]]
-        with tf.device(self.servers[0].device_name):
-            seed_0 = crypto.secure_seed()
-        with tf.device(self.servers[1].device_name):
-            seed_1 = crypto.secure_seed()
-        with tf.device(self.servers[2].device_name):
-            seed_2 = crypto.secure_seed()
+
+        if crypto.supports_seeded_randomness():
+            with tf.device(self.servers[0].device_name):
+                seed_0 = crypto.secure_seed()
+            with tf.device(self.servers[1].device_name):
+                seed_1 = crypto.secure_seed()
+            with tf.device(self.servers[2].device_name):
+                seed_2 = crypto.secure_seed()
+        else:
+            # Shape and Type are kept consistent with the 'secure_seed' version
+            with tf.device(self.servers[0].device_name):
+                seed_0 = tf.random.uniform([2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64)
+            with tf.device(self.servers[1].device_name):
+                seed_1 = tf.random.uniform([2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64)
+            with tf.device(self.servers[2].device_name):
+                seed_2 = tf.random.uniform([2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64)
 
         # Replicated keys
         # NOTE: The following `with` contexts do NOT have any impact for the Python-only operations.
@@ -130,19 +136,24 @@ class ABY3(Protocol):
     from boolean sharing to arithmetic sharing
     """
 
-        if not crypto.supports_seeded_randomness():
-            raise NotImplementedError(
-                "Secure randomness implementation is not available."
-            )
-
         # Type 1: Server 0 and 1 hold three keys, while server 2 holds two
         b2a_keys_1 = [[None, None, None], [None, None, None], [None, None, None]]
-        with tf.device(self.servers[0].device_name):
-            seed_0 = crypto.secure_seed()
-        with tf.device(self.servers[1].device_name):
-            seed_1 = crypto.secure_seed()
-        with tf.device(self.servers[2].device_name):
-            seed_2 = crypto.secure_seed()
+
+        if crypto.supports_seeded_randomness():
+            with tf.device(self.servers[0].device_name):
+                seed_0 = crypto.secure_seed()
+            with tf.device(self.servers[1].device_name):
+                seed_1 = crypto.secure_seed()
+            with tf.device(self.servers[2].device_name):
+                seed_2 = crypto.secure_seed()
+        else:
+            # Shape and Type are kept consistent with the 'secure_seed' version
+            with tf.device(self.servers[0].device_name):
+                seed_0 = tf.random.uniform([2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64)
+            with tf.device(self.servers[1].device_name):
+                seed_1 = tf.random.uniform([2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64)
+            with tf.device(self.servers[2].device_name):
+                seed_2 = tf.random.uniform([2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64)
 
         with tf.device(self.servers[0].device_name):
             b2a_keys_1[0][0] = seed_0
@@ -158,12 +169,22 @@ class ABY3(Protocol):
 
         # Type 2: Server 1 and 2 hold three keys, while server 0 holds two
         b2a_keys_2 = [[None, None, None], [None, None, None], [None, None, None]]
-        with tf.device(self.servers[0].device_name):
-            seed_0 = crypto.secure_seed()
-        with tf.device(self.servers[1].device_name):
-            seed_1 = crypto.secure_seed()
-        with tf.device(self.servers[2].device_name):
-            seed_2 = crypto.secure_seed()
+
+        if crypto.supports_seeded_randomness():
+            with tf.device(self.servers[0].device_name):
+                seed_0 = crypto.secure_seed()
+            with tf.device(self.servers[1].device_name):
+                seed_1 = crypto.secure_seed()
+            with tf.device(self.servers[2].device_name):
+                seed_2 = crypto.secure_seed()
+        else:
+            # Shape and Type are kept consistent with the 'secure_seed' version
+            with tf.device(self.servers[0].device_name):
+                seed_0 = tf.random.uniform([2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64)
+            with tf.device(self.servers[1].device_name):
+                seed_1 = tf.random.uniform([2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64)
+            with tf.device(self.servers[2].device_name):
+                seed_2 = tf.random.uniform([2], minval=tf.int64.min, maxval=tf.int64.max, dtype=tf.int64)
 
         with tf.device(self.servers[0].device_name):
             b2a_keys_2[0][0] = seed_0

--- a/tf_encrypted/protocol/aby3/aby3_test.py
+++ b/tf_encrypted/protocol/aby3/aby3_test.py
@@ -1099,4 +1099,8 @@ class TestABY3(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    """
+    Run these tests with:
+    python -m unittest aby3_test.TestABY3
+    """
     unittest.main()

--- a/tf_encrypted/protocol/aby3/aby3_test.py
+++ b/tf_encrypted/protocol/aby3/aby3_test.py
@@ -10,12 +10,21 @@ import numpy as np
 import tensorflow as tf
 
 import tf_encrypted as tfe
+from tf_encrypted.operations.secure_random import secure_random
 from tf_encrypted.protocol.aby3 import ABY3
 from tf_encrypted.protocol.aby3 import ARITHMETIC
 from tf_encrypted.protocol.aby3 import BOOLEAN
 
 
+@unittest.skipIf(
+    secure_random.secure_random_module is None,
+    "Tests will be run in TestABY3InsecureRandomness",
+)
 class TestABY3(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        print_banner("ABY3 Unit Tests with Secure Randomness")
+
     def test_add_private_private(self):
         tf.reset_default_graph()
 
@@ -1098,9 +1107,28 @@ class TestABY3(unittest.TestCase):
         os.remove(tmp_filename)
 
 
+class TestABY3InsecureRandomness(TestABY3):
+    @classmethod
+    def setUpClass(cls):
+        secure_random.secure_random_module = None
+        print_banner("ABY3 Unit Tests With Insecure Randomness")
+
+
+def print_banner(title):
+    title_length = len(title)
+    banner_length = title_length + 2 * 10
+    banner_top = "+" + ("-" * (banner_length - 2)) + "+"
+    banner_middle = "|" + " " * 9 + title + " " * 9 + "|"
+
+    print()
+    print(banner_top)
+    print(banner_middle)
+    print(banner_top)
+
+
 if __name__ == "__main__":
     """
     Run these tests with:
-    python -m unittest aby3_test.TestABY3
+    python aby3_test.py
     """
     unittest.main()

--- a/tf_encrypted/tensor/boolfactory.py
+++ b/tf_encrypted/tensor/boolfactory.py
@@ -110,10 +110,15 @@ def bool_factory():
                 )
                 value = tf.cast(value, tf.bool)
                 return DenseTensor(value)
-
-            raise NotImplementedError(
-                "Secure seeded randomness implementation is not available."
-            )
+            else:
+                value = tf.random.stateless_uniform(
+                    shape,
+                    seed,
+                    minval=minval,
+                    maxval=maxval,
+                    dtype=tf.int32)
+                value = tf.cast(value, tf.bool)
+                return DenseTensor(value)
 
         def sample_bounded(self, shape, bitlength: int):
             raise NotImplementedError("No bounded sampling for boolean type.")

--- a/tf_encrypted/tensor/boolfactory.py
+++ b/tf_encrypted/tensor/boolfactory.py
@@ -112,11 +112,8 @@ def bool_factory():
                 return DenseTensor(value)
             else:
                 value = tf.random.stateless_uniform(
-                    shape,
-                    seed,
-                    minval=minval,
-                    maxval=maxval,
-                    dtype=tf.int32)
+                    shape, seed, minval=minval, maxval=maxval, dtype=tf.int32
+                )
                 value = tf.cast(value, tf.bool)
                 return DenseTensor(value)
 

--- a/tf_encrypted/tensor/native.py
+++ b/tf_encrypted/tensor/native.py
@@ -153,11 +153,8 @@ def native_factory(
                 return DenseTensor(value)
             else:
                 value = tf.random.stateless_uniform(
-                    shape,
-                    seed,
-                    minval=minval,
-                    maxval=maxval,
-                    dtype=NATIVE_TYPE)
+                    shape, seed, minval=minval, maxval=maxval, dtype=NATIVE_TYPE
+                )
                 return DenseTensor(value)
 
         def sample_bounded(self, shape, bitlength: int):

--- a/tf_encrypted/tensor/native.py
+++ b/tf_encrypted/tensor/native.py
@@ -151,10 +151,14 @@ def native_factory(
                     seed=seed,
                 )
                 return DenseTensor(value)
-
-            raise NotImplementedError(
-                "Secure seeded randomness implementation is not available."
-            )
+            else:
+                value = tf.random.stateless_uniform(
+                    shape,
+                    seed,
+                    minval=minval,
+                    maxval=maxval,
+                    dtype=NATIVE_TYPE)
+                return DenseTensor(value)
 
         def sample_bounded(self, shape, bitlength: int):
             maxval = 2 ** bitlength


### PR DESCRIPTION
After collecting experience from some users, the existing strict requirement of "secure randomness" in ABY3 is a little annoying because the dependency `libsodium` library is quite slow to download in some areas.

In this commit, I have added the support for "insecure randomness" in ABY3, just like that in Pond and SecureNN. It no longer forces users to install libsodium before using ABY3.