### PR TITLE
Expose TF Big limb format options in Paillier primitives

### DIFF
--- a/primitives/README.md
+++ b/primitives/README.md
@@ -19,7 +19,7 @@ bazel-bin/external/primitives/build_pip_package artifacts
 This will deliver the pip package in the `artifacts` directory. To install it
 
 ```
-pip install -U artifacts/tf_encrypted_primitives-0.0.1-py3-none-any.whl
+pip install -U "artifacts/tf_encrypted_primitives-"*"-py3-none-any.whl"
 ```
 
 Note that package can be used on its own but does *not* currently work with core TF Encrypted due to difference in TensorFlow version.

--- a/primitives/tf_encrypted/primitives/paillier/primitives.py
+++ b/primitives/tf_encrypted/primitives/paillier/primitives.py
@@ -12,8 +12,9 @@ class EncryptionKey:
     Note that the generator `g` has been fixed to `1 + n`.
     """
 
-    def __init__(self, n):
-        n = tf_big.convert_to_tensor(n)
+    def __init__(self, n, bitlength=None):
+        limb_format = bitlength is not None
+        n = tf_big.convert_to_tensor(n, limb_format=limb_format, bitlength=bitlength)
 
         self.n = n
         self.nn = n * n
@@ -26,9 +27,14 @@ class EncryptionKey:
 
 
 class DecryptionKey:
-    def __init__(self, p, q):
-        self.p = tf_big.convert_to_tensor(p)
-        self.q = tf_big.convert_to_tensor(q)
+    def __init__(self, p, q, bitlength=None):
+        limb_format = bitlength is not None
+        self.p = tf_big.convert_to_tensor(
+            p, limb_format=limb_format, bitlength=bitlength
+        )
+        self.q = tf_big.convert_to_tensor(
+            q, limb_format=limb_format, bitlength=bitlength
+        )
 
         self.n = self.p * self.q
         self.nn = self.n * self.n
@@ -58,8 +64,11 @@ def gen_keypair(bitlength=2048):
 
 
 class Randomness:
-    def __init__(self, raw_randomness):
-        self.raw = tf_big.convert_to_tensor(raw_randomness)
+    def __init__(self, raw_randomness, bitlength=None):
+        limb_format = bitlength is not None
+        self.raw = tf_big.convert_to_tensor(
+            raw_randomness, limb_format=limb_format, bitlength=bitlength
+        )
 
     def export(self, dtype: tf.DType = tf.string, bitlength: Optional[int] = None):
         limb_format = bitlength is not None
@@ -73,9 +82,12 @@ def gen_randomness(ek, shape):
 
 
 class Ciphertext:
-    def __init__(self, ek: EncryptionKey, raw_ciphertext):
+    def __init__(self, ek: EncryptionKey, raw_ciphertext, bitlength=None):
+        limb_format = bitlength is not None
         self.ek = ek
-        self.raw = tf_big.convert_to_tensor(raw_ciphertext)
+        self.raw = tf_big.convert_to_tensor(
+            raw_ciphertext, limb_format=limb_format, bitlength=bitlength
+        )
 
     def export(self, dtype: tf.DType = tf.string, bitlength: Optional[int] = None):
         limb_format = bitlength is not None
@@ -89,9 +101,7 @@ class Ciphertext:
 
 
 def encrypt(
-    ek: EncryptionKey,
-    plaintext: tf.Tensor,
-    randomness: Optional[Randomness] = None,
+    ek: EncryptionKey, plaintext: tf.Tensor, randomness: Optional[Randomness] = None,
 ):
     x = tf_big.convert_to_tensor(plaintext)
 

--- a/primitives/tf_encrypted/primitives/paillier/primitives_test.py
+++ b/primitives/tf_encrypted/primitives/paillier/primitives_test.py
@@ -21,11 +21,13 @@ class EncryptionTest(parameterized.TestCase):
         for run_eagerly in [True, False]
         for export_dtype, export_expansion, c_expansion, bitlength in [
             (tf.string, (), (), None),
-            (tf.int32, (3,), (5,), 64),
-            (tf.uint8, (12,), (20,), 64)
+            (tf.int32, (65,), (129,), 2048),
+            (tf.uint8, (260,), (516,), 2048),
         ]
     )
-    def test_export(self, run_eagerly, export_dtype, export_expansion, c_expansion, bitlength):
+    def test_export(
+        self, run_eagerly, export_dtype, export_expansion, c_expansion, bitlength
+    ):
         x = np.array([[12345, 34342]])
 
         context = tf_execution_context(run_eagerly)


### PR DESCRIPTION
Depends on tf-encrypted/tf-big#73

- Add options to import/export TF Big tensors in limbs format