### PR TITLE
Fix bug: expected always unsigned, but result is signed for some params

### DIFF
--- a/operations/secure_random/generators.h
+++ b/operations/secure_random/generators.h
@@ -64,7 +64,7 @@ protected:
     typedef typename std::make_unsigned<T>::type uT;
 
     // add one for inclusive range, subtract 1 from high input to get exclusive range
-    auto range = static_cast<uT>(high) - static_cast<uT>(low) + 1;
+    uT range = static_cast<uT>(high) - static_cast<uT>(low) + 1;
 
     auto unsigned_max = std::numeric_limits<uT>::max();
 


### PR DESCRIPTION
Fix bug in this issue #900.

Problem:
`range` is expected to be an `unsigned` type, but for some params (e.g., low=-128, high=126), the usage of `auto` makes `range` becomes a `signed` type. The fix is to explicitly denote `uT` type for `range`.